### PR TITLE
Support using a common redis connection

### DIFF
--- a/scripts/create_extension_in_db.sh
+++ b/scripts/create_extension_in_db.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+TARGET_DB=$1
+PGUSER=${2:-postgres}
+PYTHON_LIBRARY_NAME='cartodb_services'
+
+function usage {
+  echo "Usage: ${0} <dbname> [dbuser]"
+}
+
+[[ -z $TARGET_DB ]] && echo "Missing DB parameter" && usage && exit 1
+
+python -c "import ${PYTHON_LIBRARY_NAME}"
+if [[ $? != 0 ]]
+then
+  echo "Missing ${PYTHON_LIBRARY_NAME} python library"
+  echo "Trying to install.."
+  cd server/lib/python/cartodb_services && sudo python setup.py install
+  python -c "import ${PYTHON_LIBRARY_NAME}" 2> /dev/null
+  if [[ $? != 0 ]]
+  then
+    echo "There are some problems with python library. Debug manually"
+    exit 1
+  fi
+fi
+
+CREATE_EXTENSION_COMMAND="CREATE EXTENSION IF NOT EXISTS"
+
+CDB_GEOCODER_EXTENSION_CREATE="${CREATE_EXTENSION_COMMAND} cdb_geocoder"
+CDB_DATASERVICES_SERVER_CREATE="${CREATE_EXTENSION_COMMAND} cdb_dataservices_server"
+
+echo "* Creating extension cdb_geocoder"
+psql -U ${PGUSER} -d ${TARGET_DB} -c "${CDB_GEOCODER_EXTENSION_CREATE}"
+echo "* Creating extension cdb_dataservices_server"
+psql -U ${PGUSER} -d ${TARGET_DB} -c "${CDB_DATASERVICES_SERVER_CREATE}"

--- a/scripts/create_extension_in_db.sh
+++ b/scripts/create_extension_in_db.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 TARGET_DB=$1
-PGUSER=${2:-postgres}
+ADMIN_PGUSER="postgres"
+PGUSER=${2:-${ADMIN_PGUSER}}
 PYTHON_LIBRARY_NAME='cartodb_services'
 
 function usage {
@@ -32,4 +33,4 @@ CDB_DATASERVICES_SERVER_CREATE="${CREATE_EXTENSION_COMMAND} cdb_dataservices_ser
 echo "* Creating extension cdb_geocoder"
 psql -U ${PGUSER} -d ${TARGET_DB} -c "${CDB_GEOCODER_EXTENSION_CREATE}"
 echo "* Creating extension cdb_dataservices_server"
-psql -U ${PGUSER} -d ${TARGET_DB} -c "${CDB_DATASERVICES_SERVER_CREATE}"
+psql -U ${ADMIN_PGUSER} -d ${TARGET_DB} -c "${CDB_DATASERVICES_SERVER_CREATE}"

--- a/server/extension/Makefile
+++ b/server/extension/Makefile
@@ -15,14 +15,17 @@ DATA =  $(NEW_EXTENSION_ARTIFACT) \
   cdb_dataservices_server--0.1.0.sql \
   cdb_dataservices_server--0.2.0.sql \
   cdb_dataservices_server--0.3.0.sql \
+  cdb_dataservices_server--0.4.0.sql \
   cdb_dataservices_server--0.1.0--0.0.1.sql \
   cdb_dataservices_server--0.0.1--0.1.0.sql \
-	cdb_dataservices_server--0.2.0--0.1.0.sql \
-	cdb_dataservices_server--0.1.0--0.2.0.sql \
-	cdb_dataservices_server--0.2.0--0.3.0.sql \
-	cdb_dataservices_server--0.3.0--0.2.0.sql \
-	cdb_dataservices_server--0.3.0--0.4.0.sql \
-	cdb_dataservices_server--0.4.0--0.3.0.sql
+  cdb_dataservices_server--0.2.0--0.1.0.sql \
+  cdb_dataservices_server--0.1.0--0.2.0.sql \
+  cdb_dataservices_server--0.2.0--0.3.0.sql \
+  cdb_dataservices_server--0.3.0--0.2.0.sql \
+  cdb_dataservices_server--0.3.0--0.4.0.sql \
+  cdb_dataservices_server--0.4.0--0.3.0.sql \
+  cdb_dataservices_server--0.5.0--0.4.0.sql \
+  cdb_dataservices_server--0.4.0--0.5.0.sql
 
 REGRESS = $(notdir $(basename $(wildcard test/$(EXTVERSION)/sql/*test.sql)))
 TEST_DIR = test/$(EXTVERSION)

--- a/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
+++ b/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
@@ -1,0 +1,52 @@
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
+RETURNS cdb_dataservices_server._redis_conf_params AS $$
+    conf_query = "SELECT cartodb.CDB_Conf_GetConf('{0}') as conf".format(config_key)
+    conf = plpy.execute(conf_query)[0]['conf']
+    if conf is None:
+      plpy.error("There is no redis configuration defined")
+    else:
+      import json
+      params = json.loads(conf)
+      return {
+        "sentinel_host": params['sentinel_host'],
+        "sentinel_port": params['sentinel_port'],
+        "sentinel_master_id": params['sentinel_master_id'],
+        "redis_host": params['redis_host']
+        "timeout": params['timeout'],
+        "redis_db": params['redis_db']
+      }
+$$ LANGUAGE plpythonu;
+
+-- Get the connection to redis from cache or create a new one
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._connect_to_redis(user_id text)
+RETURNS boolean AS $$
+  cache_key = "redis_connection_{0}".format(user_id)
+  if cache_key in GD:
+    return False
+  else:
+    from cartodb_services.tools import RedisConnection
+    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
+    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
+        metadata_config_params['sentinel_port'],
+        metadata_config_params['sentinel_master_id'],
+        metadata_config_params['redis_host'],
+        timeout=metadata_config_params['timeout'],
+        redis_db=metadata_config_params['redis_db']).redis_connection()
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
+        metrics_config_params['sentinel_port'],
+        metrics_config_params['sentinel_master_id'],
+        metrics_config_params['redis_host'],
+        timeout=metrics_config_params['timeout'],
+        redis_db=metrics_config_params['redis_db']).redis_connection()
+    GD[cache_key] = {
+      'redis_metadata_connection': redis_metadata_connection,
+      'redis_metrics_connection': redis_metrics_connection,
+    }
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;

--- a/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
+++ b/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
@@ -1,4 +1,7 @@
-ALTER TYPE cdb_dataservices_server._redis_conf_params ADD ATTRIBUTE redis_host text;
+ALTER TYPE cdb_dataservices_server._redis_conf_params ADD ATTRIBUTE redis_host text
+                                                      ADD ATTRIBUTE redis_port int
+                                                      DROP ATTRIBUTE IF EXISTS sentinel_host 
+                                                      DROP ATTRIBUTE IF EXISTS sentinel_port;
 
 -- Get the Redis configuration from the _conf table --
 CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
@@ -11,10 +14,9 @@ RETURNS cdb_dataservices_server._redis_conf_params AS $$
       import json
       params = json.loads(conf)
       return {
-        "sentinel_host": params['sentinel_host'],
-        "sentinel_port": params['sentinel_port'],
         "sentinel_master_id": params['sentinel_master_id'],
-        "redis_host": params['redis_host']
+        "redis_host": params['redis_host'],
+        "redis_port": params['redis_port'],
         "timeout": params['timeout'],
         "redis_db": params['redis_db']
       }
@@ -28,22 +30,20 @@ RETURNS boolean AS $$
     return False
   else:
     from cartodb_services.tools import RedisConnection
-    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
-        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+    metadata_config_params = plpy.execute("""select c.sentinel_master_id, c.redis_host, 
+        c.redis_port, c.timeout, c.redis_db
         from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
-    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
-        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+    metrics_config_params = plpy.execute("""select c.sentinel_master_id, c.redis_host, 
+        c.redis_port, c.timeout, c.redis_db
         from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
-    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
-        metadata_config_params['sentinel_port'],
-        metadata_config_params['sentinel_master_id'],
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_master_id'],
         metadata_config_params['redis_host'],
+        metadata_config_params['redis_port'],
         timeout=metadata_config_params['timeout'],
         redis_db=metadata_config_params['redis_db']).redis_connection()
-    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
-        metrics_config_params['sentinel_port'],
-        metrics_config_params['sentinel_master_id'],
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_master_id'],
         metrics_config_params['redis_host'],
+        metrics_config_params['redis_port'],
         timeout=metrics_config_params['timeout'],
         redis_db=metrics_config_params['redis_db']).redis_connection()
     GD[cache_key] = {

--- a/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
+++ b/server/extension/cdb_dataservices_server--0.4.0--0.5.0.sql
@@ -1,3 +1,5 @@
+ALTER TYPE cdb_dataservices_server._redis_conf_params ADD ATTRIBUTE redis_host text;
+
 -- Get the Redis configuration from the _conf table --
 CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
 RETURNS cdb_dataservices_server._redis_conf_params AS $$

--- a/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
+++ b/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
@@ -1,0 +1,49 @@
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
+RETURNS cdb_dataservices_server._redis_conf_params AS $$
+    conf_query = "SELECT cartodb.CDB_Conf_GetConf('{0}') as conf".format(config_key)
+    conf = plpy.execute(conf_query)[0]['conf']
+    if conf is None:
+      plpy.error("There is no redis configuration defined")
+    else:
+      import json
+      params = json.loads(conf)
+      return {
+        "sentinel_host": params['sentinel_host'],
+        "sentinel_port": params['sentinel_port'],
+        "sentinel_master_id": params['sentinel_master_id'],
+        "timeout": params['timeout'],
+        "redis_db": params['redis_db']
+      }
+$$ LANGUAGE plpythonu;
+
+-- Get the connection to redis from cache or create a new one
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._connect_to_redis(user_id text)
+RETURNS boolean AS $$
+  cache_key = "redis_connection_{0}".format(user_id)
+  if cache_key in GD:
+    return False
+  else:
+    from cartodb_services.tools import RedisConnection
+    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
+    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
+        metadata_config_params['sentinel_port'],
+        metadata_config_params['sentinel_master_id'],
+        timeout=metadata_config_params['timeout'],
+        redis_db=metadata_config_params['redis_db']).redis_connection()
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
+        metrics_config_params['sentinel_port'],
+        metrics_config_params['sentinel_master_id'],
+        timeout=metrics_config_params['timeout'],
+        redis_db=metrics_config_params['redis_db']).redis_connection()
+    GD[cache_key] = {
+      'redis_metadata_connection': redis_metadata_connection,
+      'redis_metrics_connection': redis_metrics_connection,
+    }
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;

--- a/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
+++ b/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
@@ -1,3 +1,5 @@
+ALTER TYPE cdb_dataservices_server._redis_conf_params DROP ATTRIBUTE IF EXISTS redis_host; 
+
 -- Get the Redis configuration from the _conf table --
 CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
 RETURNS cdb_dataservices_server._redis_conf_params AS $$

--- a/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
+++ b/server/extension/cdb_dataservices_server--0.5.0--0.4.0.sql
@@ -1,4 +1,7 @@
-ALTER TYPE cdb_dataservices_server._redis_conf_params DROP ATTRIBUTE IF EXISTS redis_host; 
+ALTER TYPE cdb_dataservices_server._redis_conf_params DROP ATTRIBUTE IF EXISTS redis_host,
+                                                      DROP ATTRIBUTE IF EXISTS redis_port,
+                                                      ADD ATTRIBUTE sentinel_host text,
+                                                      ADD ATTRIBUTE sentinel_port int; 
 
 -- Get the Redis configuration from the _conf table --
 CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)

--- a/server/extension/cdb_dataservices_server--0.5.0.sql
+++ b/server/extension/cdb_dataservices_server--0.5.0.sql
@@ -1,0 +1,912 @@
+--DO NOT MODIFY THIS FILE, IT IS GENERATED AUTOMATICALLY FROM SOURCES
+-- Complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION cdb_dataservices_server" to load this file. \quit
+CREATE TYPE cdb_dataservices_server._redis_conf_params AS (
+    sentinel_host text,
+    sentinel_port int,
+    sentinel_master_id text,
+    redis_host text,
+    redis_db text,
+    timeout float
+);
+
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
+RETURNS cdb_dataservices_server._redis_conf_params AS $$
+    conf_query = "SELECT cartodb.CDB_Conf_GetConf('{0}') as conf".format(config_key)
+    conf = plpy.execute(conf_query)[0]['conf']
+    if conf is None:
+      plpy.error("There is no redis configuration defined")
+    else:
+      import json
+      params = json.loads(conf)
+      return {
+        "sentinel_host": params['sentinel_host'],
+        "sentinel_port": params['sentinel_port'],
+        "sentinel_master_id": params['sentinel_master_id'],
+        "redis_host": params['redis_host'],
+        "timeout": params['timeout'],
+        "redis_db": params['redis_db']
+      }
+$$ LANGUAGE plpythonu;
+
+-- Get the connection to redis from cache or create a new one
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._connect_to_redis(user_id text)
+RETURNS boolean AS $$
+  cache_key = "redis_connection_{0}".format(user_id)
+  if cache_key in GD:
+    return False
+  else:
+    from cartodb_services.tools import RedisConnection
+    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
+    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
+        metadata_config_params['sentinel_port'],
+        metadata_config_params['sentinel_master_id'],
+        metadata_config_params['redis_host'],
+        timeout=metadata_config_params['timeout'],
+        redis_db=metadata_config_params['redis_db']).redis_connection()
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
+        metrics_config_params['sentinel_port'],
+        metrics_config_params['sentinel_master_id'],
+        metrics_config_params['redis_host'],
+        timeout=metrics_config_params['timeout'],
+        redis_db=metrics_config_params['redis_db']).redis_connection()
+    GD[cache_key] = {
+      'redis_metadata_connection': redis_metadata_connection,
+      'redis_metrics_connection': redis_metrics_connection,
+    }
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_geocoder_config(username text, orgname text)
+RETURNS boolean AS $$
+  cache_key = "user_geocoder_config_{0}".format(username)
+  if cache_key in GD:
+    return False
+  else:
+    import json
+    from cartodb_services.metrics import GeocoderConfig
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metadata_connection']
+    heremaps_conf_json = plpy.execute("SELECT cartodb.CDB_Conf_GetConf('heremaps_conf') as heremaps_conf", 1)[0]['heremaps_conf']
+    if not heremaps_conf_json:
+      heremaps_app_id = None
+      heremaps_app_code = None
+    else:
+      heremaps_conf = json.loads(heremaps_conf_json)
+      heremaps_app_id = heremaps_conf['app_id']
+      heremaps_app_code = heremaps_conf['app_code']
+    geocoder_config = GeocoderConfig(redis_conn, username, orgname, heremaps_app_id, heremaps_app_code)
+    # --Think about the security concerns with this kind of global cache, it should be only available
+    # --for this user session but...
+    GD[cache_key] = geocoder_config
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;
+
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_routing_config(username text, orgname text)
+RETURNS boolean AS $$
+  cache_key = "user_routing_config_{0}".format(username)
+  if cache_key in GD:
+    return False
+  else:
+    import json
+    from cartodb_services.metrics import RoutingConfig
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metadata_connection']
+    heremaps_conf_json = plpy.execute("SELECT cartodb.CDB_Conf_GetConf('heremaps_conf') as heremaps_conf", 1)[0]['heremaps_conf']
+    if not heremaps_conf_json:
+      heremaps_app_id = None
+      heremaps_app_code = None
+    else:
+      heremaps_conf = json.loads(heremaps_conf_json)
+      heremaps_app_id = heremaps_conf['app_id']
+      heremaps_app_code = heremaps_conf['app_code']
+    routing_config = RoutingConfig(redis_conn, username, orgname, heremaps_app_id, heremaps_app_code)
+    # --Think about the security concerns with this kind of global cache, it should be only available
+    # --for this user session but...
+    GD[cache_key] = routing_config
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;
+-- Geocodes a street address given a searchtext and a state and/or country
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_geocoder_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+
+  if user_geocoder_config.heremaps_geocoder:
+    here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_geocode_street_point($1, $2, $3, $4, $5, $6) as point; ", ["text", "text", "text", "text", "text", "text"])
+    return plpy.execute(here_plan, [username, orgname, searchtext, city, state_province, country], 1)[0]['point']
+  elif user_geocoder_config.google_geocoder:
+    google_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_google_geocode_street_point($1, $2, $3, $4, $5, $6) as point; ", ["text", "text", "text", "text", "text", "text"])
+    return plpy.execute(google_plan, [username, orgname, searchtext, city, state_province, country], 1)[0]['point']
+  else:
+    plpy.error('Requested geocoder is not available')
+
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_here_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  from cartodb_services.here import HereMapsGeocoder
+  from cartodb_services.metrics import QuotaService
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+
+  # -- Check the quota
+  quota_service = QuotaService(user_geocoder_config, redis_conn)
+  if not quota_service.check_user_quota():
+    plpy.error('You have reach the limit of your quota')
+
+  try:
+    geocoder = HereMapsGeocoder(user_geocoder_config.heremaps_app_id, user_geocoder_config.heremaps_app_code)
+    coordinates = geocoder.geocode(searchtext=searchtext, city=city, state=state_province, country=country)
+    if coordinates:
+      quota_service.increment_success_geocoder_use()
+      plan = plpy.prepare("SELECT ST_SetSRID(ST_MakePoint($1, $2), 4326); ", ["double precision", "double precision"])
+      point = plpy.execute(plan, [coordinates[0], coordinates[1]], 1)[0]
+      return point['st_setsrid']
+    else:
+      quota_service.increment_empty_geocoder_use()
+      return None
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to geocode using here maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_google_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  from cartodb_services.google import GoogleMapsGeocoder
+  from cartodb_services.metrics import QuotaService
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+  quota_service = QuotaService(user_geocoder_config, redis_conn)
+
+  try:
+    geocoder = GoogleMapsGeocoder(user_geocoder_config.google_client_id, user_geocoder_config.google_api_key)
+    coordinates = geocoder.geocode(searchtext=searchtext, city=city, state=state_province, country=country)
+    if coordinates:
+      quota_service.increment_success_geocoder_use()
+      plan = plpy.prepare("SELECT ST_SetSRID(ST_MakePoint($1, $2), 4326); ", ["double precision", "double precision"])
+      point = plpy.execute(plan, [coordinates[0], coordinates[1]], 1)[0]
+      return point['st_setsrid']
+    else:
+      quota_service.increment_empty_geocoder_use()
+      return None
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to geocode using google maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin0_polygon(username text, orgname text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin0_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [country_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin0_polygon(country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT n.the_geom as geom INTO ret
+      FROM (SELECT q, lower(regexp_replace(q, '[^a-zA-Z\u00C0-\u00ff]+', '', 'g'))::text x
+        FROM (SELECT country_name q) g) d
+      LEFT OUTER JOIN admin0_synonyms s ON name_ = d.x
+      LEFT OUTER JOIN ne_admin0_v3 n ON s.adm0_a3 = n.adm0_a3 GROUP BY d.q, n.the_geom, s.adm0_a3;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+---- cdb_geocode_admin1_polygon(admin1_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin1_polygon(username text, orgname text, admin1_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin1_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [admin1_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin1_polygon(username text, orgname text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin1_polygon(trim($1), trim($2)) AS mypolygon", ["text", "text"])
+      rv = plpy.execute(plan, [admin1_name, country_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+
+---- cdb_geocode_admin1_polygon(admin1_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin1_polygon(admin1_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT q, (
+          SELECT the_geom
+          FROM global_province_polygons
+          WHERE d.c = ANY (synonyms)
+          ORDER BY frequency DESC LIMIT 1
+        ) geom
+      FROM (
+        SELECT
+          trim(replace(lower(admin1_name),'.',' ')) c, admin1_name q
+        ) d
+      ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    WITH p AS (SELECT r.c, r.q, (SELECT iso3 FROM country_decoder WHERE lower(country_name) = ANY (synonyms)) i FROM (SELECT  trim(replace(lower(admin1_name),'.',' ')) c, country_name q) r)
+    SELECT
+      geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_province_polygons
+          WHERE p.c = ANY (synonyms)
+          AND iso3 = p.i
+          ORDER BY frequency DESC LIMIT 1
+        ) geom
+      FROM p) n;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_namedplace_point(city_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1)) AS mypoint", ["text"])
+      rv = plpy.execute(plan, [city_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_namedplace_point(city_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1), trim($2)) AS mypoint", ["text", "text"])
+      rv = plpy.execute(plan, [city_name, country_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1), trim($2), trim($3)) AS mypoint", ["text", "text", "text"])
+      rv = plpy.execute(plan, [city_name, admin1_name, country_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+
+---- cdb_geocode_namedplace_point(city_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH best AS (SELECT s AS q, (SELECT the_geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) ORDER BY population DESC LIMIT 1) AS geom FROM (SELECT city_name as s) p),
+        next AS (SELECT p.s AS q, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM (SELECT city_name as s) p WHERE p.s NOT IN (SELECT q FROM best WHERE geom IS NOT NULL))
+        SELECT q, geom, TRUE AS success FROM best WHERE geom IS NOT NULL
+        UNION ALL
+        SELECT q, geom, CASE WHEN geom IS NULL THEN FALSE ELSE TRUE END AS success FROM next
+  ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_namedplace_point(city_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH p AS (SELECT r.s, r.c, (SELECT iso2 FROM country_decoder WHERE lower(r.c) = ANY (synonyms)) i FROM (SELECT city_name AS s, country_name::text AS c) r),
+        best AS (SELECT p.s AS q, p.c AS c, (SELECT gp.the_geom AS geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) AND gp.iso2 = p.i ORDER BY population DESC LIMIT 1) AS geom FROM p),
+        next AS (SELECT p.s AS q, p.c AS c, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND gp.iso2 = p.i AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM p WHERE p.s NOT IN (SELECT q FROM best WHERE c = p.c AND geom IS NOT NULL))
+        SELECT geom FROM best WHERE geom IS NOT NULL
+        UNION ALL
+        SELECT geom FROM next
+   ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH inputcountry AS (
+        SELECT iso2 as isoTwo FROM country_decoder WHERE lower(country_name) = ANY (synonyms) LIMIT 1
+        ),
+    p AS (
+       SELECT r.s, r.a1, (SELECT admin1 FROM admin1_decoder, inputcountry WHERE lower(r.a1) = ANY (synonyms) AND admin1_decoder.iso2 = inputcountry.isoTwo LIMIT 1) i FROM (SELECT city_name AS s, admin1_name::text AS a1) r),
+       best AS (SELECT p.s AS q, p.a1 as a1, (SELECT gp.the_geom AS geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) AND gp.admin1 = p.i ORDER BY population DESC LIMIT 1) AS geom FROM p),
+       next AS (SELECT p.s AS q, p.a1 AS a1, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND ga.admin1 = p.i AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM p WHERE p.s NOT IN (SELECT q FROM best WHERE geom IS NOT NULL))
+       SELECT geom FROM best WHERE geom IS NOT NULL
+       UNION ALL
+       SELECT geom FROM next
+   ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_point(username text, orgname text, code text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_point(trim($1)) AS mypoint", ["text"])
+      rv = plpy.execute(plan, [code], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_point(username text, orgname text, code text, country text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_point(trim($1), trim($2)) AS mypoint", ["TEXT", "TEXT"])
+      rv = plpy.execute(plan, [code, country], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_polygon(username text, orgname text, code text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [code], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_polygon(username text, orgname text, code text, country text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_polygon(trim($1), trim($2)) AS mypolygon", ["TEXT", "TEXT"])
+      rv = plpy.execute(plan, [code, country], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_point(code text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_points
+          WHERE postal_code = upper(d.q)
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_point(code text, country text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_points
+          WHERE postal_code = upper(d.q)
+            AND iso3 = (
+                SELECT iso3 FROM country_decoder WHERE
+                lower(country) = ANY (synonyms) LIMIT 1
+            )
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_polygon(code text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_polygons
+          WHERE postal_code = upper(d.q)
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_polygon(code text, country text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_polygons
+          WHERE postal_code = upper(d.q)
+            AND iso3 = (
+                SELECT iso3 FROM country_decoder WHERE
+                lower(country) = ANY (synonyms) LIMIT 1
+            )
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_ipaddress_point(username text, orgname text, ip text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_ipaddress_point(trim($1)) AS mypoint", ["TEXT"])
+      rv = plpy.execute(plan, [ip], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_ipaddress_point(ip text)
+RETURNS Geometry AS $$
+    DECLARE
+        ret Geometry;
+
+        new_ip INET;
+    BEGIN
+    BEGIN
+        IF family(ip::inet) = 6 THEN
+            new_ip := ip::inet;
+        ELSE
+            new_ip := ('::ffff:' || ip)::inet;
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        SELECT NULL as geom INTO ret;
+        RETURN ret;
+    END;
+
+    WITH
+        ips AS (SELECT ip s, new_ip net),
+        matches AS (SELECT s, (SELECT the_geom FROM ip_address_locations WHERE network_start_ip <= ips.net ORDER BY network_start_ip DESC LIMIT 1) geom FROM ips)
+    SELECT geom INTO ret
+        FROM matches;
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+CREATE TYPE cdb_dataservices_server.isoline AS (center geometry(Geometry,4326), data_range integer, the_geom geometry(Multipolygon,4326));
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_here_routing_isolines(username TEXT, orgname TEXT, type TEXT, source geometry(Geometry, 4326), mode TEXT, data_range integer[], options text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  import json
+  from cartodb_services.here import HereMapsRoutingIsoline
+  from cartodb_services.metrics import QuotaService
+  from cartodb_services.here.types import geo_polyline_to_multipolygon
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_routing_config = GD["user_routing_config_{0}".format(username)]
+
+  quota_service = QuotaService(user_routing_config, redis_conn)
+
+  try:
+    client = HereMapsRoutingIsoline(user_routing_config.heremaps_app_id, user_routing_config.heremaps_app_code, base_url = HereMapsRoutingIsoline.PRODUCTION_ROUTING_BASE_URL)
+
+    if source:
+      lat = plpy.execute("SELECT ST_Y('%s') AS lat" % source)[0]['lat']
+      lon = plpy.execute("SELECT ST_X('%s') AS lon" % source)[0]['lon']
+      source_str = 'geo!%f,%f' % (lat, lon)
+    else:
+      source_str = None
+
+    if type == 'isodistance':
+      resp = client.calculate_isodistance(source_str, mode, data_range, options)
+    elif type == 'isochrone':
+      resp = client.calculate_isochrone(source_str, mode, data_range, options)
+
+    if resp:
+      result = []
+      for isoline in resp:
+        data_range_n = isoline['range']
+        polyline = isoline['geom']
+        multipolygon = geo_polyline_to_multipolygon(polyline)
+        result.append([source, data_range_n, multipolygon])
+      quota_service.increment_success_geocoder_use()
+      quota_service.increment_isolines_service_use(len(resp))
+      return result
+    else:
+      quota_service.increment_empty_geocoder_use()
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to obtain isodistances using here maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu SECURITY DEFINER;
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isodistance(username TEXT, orgname TEXT, source geometry(Geometry, 4326), mode TEXT, range integer[], options text[] DEFAULT array[]::text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_isolines_config = GD["user_routing_config_{0}".format(username)]
+  type = 'isodistance'
+
+  here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
+  result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
+  isolines = []
+  for element in result:
+    isoline = element['isoline']
+    isoline = isoline.translate(None, "()").split(',')
+    isolines.append(isoline)
+
+  return isolines
+$$ LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isochrone(username TEXT, orgname TEXT, source geometry(Geometry, 4326), mode TEXT, range integer[], options text[] DEFAULT array[]::text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_isolines_config = GD["user_routing_config_{0}".format(username)]
+  type = 'isochrone'
+
+  here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
+  result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
+  isolines = []
+  for element in result:
+    isoline = element['isoline']
+    isoline = isoline.translate(None, "()").split(',')
+    isolines.append(isoline)
+
+  return isolines
+$$ LANGUAGE plpythonu;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT *
+        FROM   pg_catalog.pg_user
+        WHERE  usename = 'geocoder_api') THEN
+
+            CREATE USER geocoder_api;
+    END IF;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA cdb_dataservices_server TO geocoder_api;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO geocoder_api;
+    GRANT USAGE ON SCHEMA cdb_dataservices_server TO geocoder_api;
+    GRANT USAGE ON SCHEMA public TO geocoder_api;
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO geocoder_api;
+END$$;

--- a/server/extension/cdb_dataservices_server--0.5.0.sql
+++ b/server/extension/cdb_dataservices_server--0.5.0.sql
@@ -2,10 +2,9 @@
 -- Complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION cdb_dataservices_server" to load this file. \quit
 CREATE TYPE cdb_dataservices_server._redis_conf_params AS (
-    sentinel_host text,
-    sentinel_port int,
     sentinel_master_id text,
     redis_host text,
+    redis_port int,
     redis_db text,
     timeout float
 );
@@ -21,10 +20,9 @@ RETURNS cdb_dataservices_server._redis_conf_params AS $$
       import json
       params = json.loads(conf)
       return {
-        "sentinel_host": params['sentinel_host'],
-        "sentinel_port": params['sentinel_port'],
         "sentinel_master_id": params['sentinel_master_id'],
         "redis_host": params['redis_host'],
+        "redis_port": params['redis_port'],
         "timeout": params['timeout'],
         "redis_db": params['redis_db']
       }
@@ -38,22 +36,20 @@ RETURNS boolean AS $$
     return False
   else:
     from cartodb_services.tools import RedisConnection
-    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
-        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+    metadata_config_params = plpy.execute("""select c.sentinel_master_id, c.redis_host, 
+        c.redis_port, c.timeout, c.redis_db
         from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
-    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
-        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+    metrics_config_params = plpy.execute("""select c.sentinel_master_id, c.redis_host, 
+        c.redis_port, c.timeout, c.redis_db
         from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
-    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
-        metadata_config_params['sentinel_port'],
-        metadata_config_params['sentinel_master_id'],
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_master_id'],
         metadata_config_params['redis_host'],
+        metadata_config_params['redis_port'],
         timeout=metadata_config_params['timeout'],
         redis_db=metadata_config_params['redis_db']).redis_connection()
-    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
-        metrics_config_params['sentinel_port'],
-        metrics_config_params['sentinel_master_id'],
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_master_id'],
         metrics_config_params['redis_host'],
+        metrics_config_params['redis_port'],
         timeout=metrics_config_params['timeout'],
         redis_db=metrics_config_params['redis_db']).redis_connection()
     GD[cache_key] = {

--- a/server/extension/cdb_dataservices_server.control
+++ b/server/extension/cdb_dataservices_server.control
@@ -1,5 +1,5 @@
 comment = 'CartoDB dataservices server extension'
-default_version = '0.4.0'
+default_version = '0.5.0'
 requires = 'plpythonu, postgis, cdb_geocoder'
 superuser = true
 schema = cdb_dataservices_server

--- a/server/extension/sql/0.5.0/00_header.sql
+++ b/server/extension/sql/0.5.0/00_header.sql
@@ -1,0 +1,3 @@
+--DO NOT MODIFY THIS FILE, IT IS GENERATED AUTOMATICALLY FROM SOURCES
+-- Complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION cdb_dataservices_server" to load this file. \quit

--- a/server/extension/sql/0.5.0/10_redis_helper.sql
+++ b/server/extension/sql/0.5.0/10_redis_helper.sql
@@ -1,0 +1,61 @@
+CREATE TYPE cdb_dataservices_server._redis_conf_params AS (
+    sentinel_host text,
+    sentinel_port int,
+    sentinel_master_id text,
+    redis_host text,
+    redis_db text,
+    timeout float
+);
+
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_redis_conf_v2(config_key text)
+RETURNS cdb_dataservices_server._redis_conf_params AS $$
+    conf_query = "SELECT cartodb.CDB_Conf_GetConf('{0}') as conf".format(config_key)
+    conf = plpy.execute(conf_query)[0]['conf']
+    if conf is None:
+      plpy.error("There is no redis configuration defined")
+    else:
+      import json
+      params = json.loads(conf)
+      return {
+        "sentinel_host": params['sentinel_host'],
+        "sentinel_port": params['sentinel_port'],
+        "sentinel_master_id": params['sentinel_master_id'],
+        "redis_host": params['redis_host'],
+        "timeout": params['timeout'],
+        "redis_db": params['redis_db']
+      }
+$$ LANGUAGE plpythonu;
+
+-- Get the connection to redis from cache or create a new one
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._connect_to_redis(user_id text)
+RETURNS boolean AS $$
+  cache_key = "redis_connection_{0}".format(user_id)
+  if cache_key in GD:
+    return False
+  else:
+    from cartodb_services.tools import RedisConnection
+    metadata_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metadata_config') c;""")[0]
+    metrics_config_params = plpy.execute("""select c.sentinel_host, c.sentinel_port,
+        c.sentinel_master_id, c.redis_host, c.timeout, c.redis_db
+        from cdb_dataservices_server._get_redis_conf_v2('redis_metrics_config') c;""")[0]
+    redis_metadata_connection = RedisConnection(metadata_config_params['sentinel_host'],
+        metadata_config_params['sentinel_port'],
+        metadata_config_params['sentinel_master_id'],
+        metadata_config_params['redis_host'],
+        timeout=metadata_config_params['timeout'],
+        redis_db=metadata_config_params['redis_db']).redis_connection()
+    redis_metrics_connection = RedisConnection(metrics_config_params['sentinel_host'],
+        metrics_config_params['sentinel_port'],
+        metrics_config_params['sentinel_master_id'],
+        metrics_config_params['redis_host'],
+        timeout=metrics_config_params['timeout'],
+        redis_db=metrics_config_params['redis_db']).redis_connection()
+    GD[cache_key] = {
+      'redis_metadata_connection': redis_metadata_connection,
+      'redis_metrics_connection': redis_metrics_connection,
+    }
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;

--- a/server/extension/sql/0.5.0/15_config_helper.sql
+++ b/server/extension/sql/0.5.0/15_config_helper.sql
@@ -1,0 +1,51 @@
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_geocoder_config(username text, orgname text)
+RETURNS boolean AS $$
+  cache_key = "user_geocoder_config_{0}".format(username)
+  if cache_key in GD:
+    return False
+  else:
+    import json
+    from cartodb_services.metrics import GeocoderConfig
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metadata_connection']
+    heremaps_conf_json = plpy.execute("SELECT cartodb.CDB_Conf_GetConf('heremaps_conf') as heremaps_conf", 1)[0]['heremaps_conf']
+    if not heremaps_conf_json:
+      heremaps_app_id = None
+      heremaps_app_code = None
+    else:
+      heremaps_conf = json.loads(heremaps_conf_json)
+      heremaps_app_id = heremaps_conf['app_id']
+      heremaps_app_code = heremaps_conf['app_code']
+    geocoder_config = GeocoderConfig(redis_conn, username, orgname, heremaps_app_id, heremaps_app_code)
+    # --Think about the security concerns with this kind of global cache, it should be only available
+    # --for this user session but...
+    GD[cache_key] = geocoder_config
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;
+
+-- Get the Redis configuration from the _conf table --
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._get_routing_config(username text, orgname text)
+RETURNS boolean AS $$
+  cache_key = "user_routing_config_{0}".format(username)
+  if cache_key in GD:
+    return False
+  else:
+    import json
+    from cartodb_services.metrics import RoutingConfig
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metadata_connection']
+    heremaps_conf_json = plpy.execute("SELECT cartodb.CDB_Conf_GetConf('heremaps_conf') as heremaps_conf", 1)[0]['heremaps_conf']
+    if not heremaps_conf_json:
+      heremaps_app_id = None
+      heremaps_app_code = None
+    else:
+      heremaps_conf = json.loads(heremaps_conf_json)
+      heremaps_app_id = heremaps_conf['app_id']
+      heremaps_app_code = heremaps_conf['app_code']
+    routing_config = RoutingConfig(redis_conn, username, orgname, heremaps_app_id, heremaps_app_code)
+    # --Think about the security concerns with this kind of global cache, it should be only available
+    # --for this user session but...
+    GD[cache_key] = routing_config
+    return True
+$$ LANGUAGE plpythonu SECURITY DEFINER;

--- a/server/extension/sql/0.5.0/20_geocode_street.sql
+++ b/server/extension/sql/0.5.0/20_geocode_street.sql
@@ -1,0 +1,84 @@
+-- Geocodes a street address given a searchtext and a state and/or country
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_geocoder_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+
+  if user_geocoder_config.heremaps_geocoder:
+    here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_geocode_street_point($1, $2, $3, $4, $5, $6) as point; ", ["text", "text", "text", "text", "text", "text"])
+    return plpy.execute(here_plan, [username, orgname, searchtext, city, state_province, country], 1)[0]['point']
+  elif user_geocoder_config.google_geocoder:
+    google_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_google_geocode_street_point($1, $2, $3, $4, $5, $6) as point; ", ["text", "text", "text", "text", "text", "text"])
+    return plpy.execute(google_plan, [username, orgname, searchtext, city, state_province, country], 1)[0]['point']
+  else:
+    plpy.error('Requested geocoder is not available')
+
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_here_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  from cartodb_services.here import HereMapsGeocoder
+  from cartodb_services.metrics import QuotaService
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+
+  # -- Check the quota
+  quota_service = QuotaService(user_geocoder_config, redis_conn)
+  if not quota_service.check_user_quota():
+    plpy.error('You have reach the limit of your quota')
+
+  try:
+    geocoder = HereMapsGeocoder(user_geocoder_config.heremaps_app_id, user_geocoder_config.heremaps_app_code)
+    coordinates = geocoder.geocode(searchtext=searchtext, city=city, state=state_province, country=country)
+    if coordinates:
+      quota_service.increment_success_geocoder_use()
+      plan = plpy.prepare("SELECT ST_SetSRID(ST_MakePoint($1, $2), 4326); ", ["double precision", "double precision"])
+      point = plpy.execute(plan, [coordinates[0], coordinates[1]], 1)[0]
+      return point['st_setsrid']
+    else:
+      quota_service.increment_empty_geocoder_use()
+      return None
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to geocode using here maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_google_geocode_street_point(username TEXT, orgname TEXT, searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  from cartodb_services.google import GoogleMapsGeocoder
+  from cartodb_services.metrics import QuotaService
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_geocoder_config = GD["user_geocoder_config_{0}".format(username)]
+  quota_service = QuotaService(user_geocoder_config, redis_conn)
+
+  try:
+    geocoder = GoogleMapsGeocoder(user_geocoder_config.google_client_id, user_geocoder_config.google_api_key)
+    coordinates = geocoder.geocode(searchtext=searchtext, city=city, state=state_province, country=country)
+    if coordinates:
+      quota_service.increment_success_geocoder_use()
+      plan = plpy.prepare("SELECT ST_SetSRID(ST_MakePoint($1, $2), 4326); ", ["double precision", "double precision"])
+      point = plpy.execute(plan, [coordinates[0], coordinates[1]], 1)[0]
+      return point['st_setsrid']
+    else:
+      quota_service.increment_empty_geocoder_use()
+      return None
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to geocode using google maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/0.5.0/30_admin0.sql
+++ b/server/extension/sql/0.5.0/30_admin0.sql
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin0_polygon(username text, orgname text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin0_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [country_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin0_polygon(country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT n.the_geom as geom INTO ret
+      FROM (SELECT q, lower(regexp_replace(q, '[^a-zA-Z\u00C0-\u00ff]+', '', 'g'))::text x
+        FROM (SELECT country_name q) g) d
+      LEFT OUTER JOIN admin0_synonyms s ON name_ = d.x
+      LEFT OUTER JOIN ne_admin0_v3 n ON s.adm0_a3 = n.adm0_a3 GROUP BY d.q, n.the_geom, s.adm0_a3;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;

--- a/server/extension/sql/0.5.0/40_admin1.sql
+++ b/server/extension/sql/0.5.0/40_admin1.sql
@@ -1,0 +1,117 @@
+---- cdb_geocode_admin1_polygon(admin1_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin1_polygon(username text, orgname text, admin1_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin1_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [admin1_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_admin1_polygon(username text, orgname text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_admin1_polygon(trim($1), trim($2)) AS mypolygon", ["text", "text"])
+      rv = plpy.execute(plan, [admin1_name, country_name], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+
+---- cdb_geocode_admin1_polygon(admin1_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin1_polygon(admin1_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT q, (
+          SELECT the_geom
+          FROM global_province_polygons
+          WHERE d.c = ANY (synonyms)
+          ORDER BY frequency DESC LIMIT 1
+        ) geom
+      FROM (
+        SELECT
+          trim(replace(lower(admin1_name),'.',' ')) c, admin1_name q
+        ) d
+      ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    WITH p AS (SELECT r.c, r.q, (SELECT iso3 FROM country_decoder WHERE lower(country_name) = ANY (synonyms)) i FROM (SELECT  trim(replace(lower(admin1_name),'.',' ')) c, country_name q) r)
+    SELECT
+      geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_province_polygons
+          WHERE p.c = ANY (synonyms)
+          AND iso3 = p.i
+          ORDER BY frequency DESC LIMIT 1
+        ) geom
+      FROM p) n;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+

--- a/server/extension/sql/0.5.0/50_namedplaces.sql
+++ b/server/extension/sql/0.5.0/50_namedplaces.sql
@@ -1,0 +1,164 @@
+---- cdb_geocode_namedplace_point(city_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1)) AS mypoint", ["text"])
+      rv = plpy.execute(plan, [city_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_namedplace_point(city_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1), trim($2)) AS mypoint", ["text", "text"])
+      rv = plpy.execute(plan, [city_name, country_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+---- cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_namedplace_point(username text, orgname text, city_name text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_namedplace_point(trim($1), trim($2), trim($3)) AS mypoint", ["text", "text", "text"])
+      rv = plpy.execute(plan, [city_name, admin1_name, country_name], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+
+---- cdb_geocode_namedplace_point(city_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH best AS (SELECT s AS q, (SELECT the_geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) ORDER BY population DESC LIMIT 1) AS geom FROM (SELECT city_name as s) p),
+        next AS (SELECT p.s AS q, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM (SELECT city_name as s) p WHERE p.s NOT IN (SELECT q FROM best WHERE geom IS NOT NULL))
+        SELECT q, geom, TRUE AS success FROM best WHERE geom IS NOT NULL
+        UNION ALL
+        SELECT q, geom, CASE WHEN geom IS NULL THEN FALSE ELSE TRUE END AS success FROM next
+  ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_namedplace_point(city_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH p AS (SELECT r.s, r.c, (SELECT iso2 FROM country_decoder WHERE lower(r.c) = ANY (synonyms)) i FROM (SELECT city_name AS s, country_name::text AS c) r),
+        best AS (SELECT p.s AS q, p.c AS c, (SELECT gp.the_geom AS geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) AND gp.iso2 = p.i ORDER BY population DESC LIMIT 1) AS geom FROM p),
+        next AS (SELECT p.s AS q, p.c AS c, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND gp.iso2 = p.i AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM p WHERE p.s NOT IN (SELECT q FROM best WHERE c = p.c AND geom IS NOT NULL))
+        SELECT geom FROM best WHERE geom IS NOT NULL
+        UNION ALL
+        SELECT geom FROM next
+   ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+---- cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+  SELECT geom INTO ret
+  FROM (
+    WITH inputcountry AS (
+        SELECT iso2 as isoTwo FROM country_decoder WHERE lower(country_name) = ANY (synonyms) LIMIT 1
+        ),
+    p AS (
+       SELECT r.s, r.a1, (SELECT admin1 FROM admin1_decoder, inputcountry WHERE lower(r.a1) = ANY (synonyms) AND admin1_decoder.iso2 = inputcountry.isoTwo LIMIT 1) i FROM (SELECT city_name AS s, admin1_name::text AS a1) r),
+       best AS (SELECT p.s AS q, p.a1 as a1, (SELECT gp.the_geom AS geom FROM global_cities_points_limited gp WHERE gp.lowername = lower(p.s) AND gp.admin1 = p.i ORDER BY population DESC LIMIT 1) AS geom FROM p),
+       next AS (SELECT p.s AS q, p.a1 AS a1, (SELECT gp.the_geom FROM global_cities_points_limited gp, global_cities_alternates_limited ga WHERE lower(p.s) = ga.lowername AND ga.admin1 = p.i AND ga.geoname_id = gp.geoname_id ORDER BY preferred DESC LIMIT 1) geom FROM p WHERE p.s NOT IN (SELECT q FROM best WHERE geom IS NOT NULL))
+       SELECT geom FROM best WHERE geom IS NOT NULL
+       UNION ALL
+       SELECT geom FROM next
+   ) v;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+

--- a/server/extension/sql/0.5.0/60_postalcodes.sql
+++ b/server/extension/sql/0.5.0/60_postalcodes.sql
@@ -1,0 +1,219 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_point(username text, orgname text, code text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_point(trim($1)) AS mypoint", ["text"])
+      rv = plpy.execute(plan, [code], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_point(username text, orgname text, code text, country text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_point(trim($1), trim($2)) AS mypoint", ["TEXT", "TEXT"])
+      rv = plpy.execute(plan, [code, country], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_polygon(username text, orgname text, code text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_polygon(trim($1)) AS mypolygon", ["text"])
+      rv = plpy.execute(plan, [code], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_postalcode_polygon(username text, orgname text, code text, country text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_postalcode_polygon(trim($1), trim($2)) AS mypolygon", ["TEXT", "TEXT"])
+      rv = plpy.execute(plan, [code, country], 1)
+      result = rv[0]["mypolygon"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_point(code text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_points
+          WHERE postal_code = upper(d.q)
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_point(code text, country text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_points
+          WHERE postal_code = upper(d.q)
+            AND iso3 = (
+                SELECT iso3 FROM country_decoder WHERE
+                lower(country) = ANY (synonyms) LIMIT 1
+            )
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_polygon(code text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_polygons
+          WHERE postal_code = upper(d.q)
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_postalcode_polygon(code text, country text)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT geom INTO ret
+    FROM (
+      SELECT
+        q, (
+          SELECT the_geom
+          FROM global_postal_code_polygons
+          WHERE postal_code = upper(d.q)
+            AND iso3 = (
+                SELECT iso3 FROM country_decoder WHERE
+                lower(country) = ANY (synonyms) LIMIT 1
+            )
+          LIMIT 1
+        ) geom
+      FROM (SELECT code q) d
+    ) v;
+
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;

--- a/server/extension/sql/0.5.0/70_ips.sql
+++ b/server/extension/sql/0.5.0/70_ips.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_ipaddress_point(username text, orgname text, ip text)
+RETURNS Geometry AS $$
+    from cartodb_services.metrics import QuotaService
+    from cartodb_services.metrics import InternalGeocoderConfig
+
+    plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+    redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+    user_geocoder_config = InternalGeocoderConfig(redis_conn, username, orgname)
+
+    quota_service = QuotaService(user_geocoder_config, redis_conn)
+    try:
+      plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_geocode_ipaddress_point(trim($1)) AS mypoint", ["TEXT"])
+      rv = plpy.execute(plan, [ip], 1)
+      result = rv[0]["mypoint"]
+      if result:
+        quota_service.increment_success_geocoder_use()
+        return result
+      else:
+        quota_service.increment_empty_geocoder_use()
+        return None
+    except BaseException as e:
+      import sys, traceback
+      type_, value_, traceback_ = sys.exc_info()
+      quota_service.increment_failed_geocoder_use()
+      error_msg = 'There was an error trying to geocode using admin0 geocoder: {0}'.format(e)
+      plpy.notice(traceback.format_tb(traceback_))
+      plpy.error(error_msg)
+    finally:
+      quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu;
+
+--------------------------------------------------------------------------------
+
+-- Implementation of the server extension
+-- Note: these functions depend on the cdb_geocoder extension
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_geocode_ipaddress_point(ip text)
+RETURNS Geometry AS $$
+    DECLARE
+        ret Geometry;
+
+        new_ip INET;
+    BEGIN
+    BEGIN
+        IF family(ip::inet) = 6 THEN
+            new_ip := ip::inet;
+        ELSE
+            new_ip := ('::ffff:' || ip)::inet;
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        SELECT NULL as geom INTO ret;
+        RETURN ret;
+    END;
+
+    WITH
+        ips AS (SELECT ip s, new_ip net),
+        matches AS (SELECT s, (SELECT the_geom FROM ip_address_locations WHERE network_start_ip <= ips.net ORDER BY network_start_ip DESC LIMIT 1) geom FROM ips)
+    SELECT geom INTO ret
+        FROM matches;
+    RETURN ret;
+END
+$$ LANGUAGE plpgsql;

--- a/server/extension/sql/0.5.0/80_routing_helper.sql
+++ b/server/extension/sql/0.5.0/80_routing_helper.sql
@@ -1,0 +1,51 @@
+CREATE TYPE cdb_dataservices_server.isoline AS (center geometry(Geometry,4326), data_range integer, the_geom geometry(Multipolygon,4326));
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server._cdb_here_routing_isolines(username TEXT, orgname TEXT, type TEXT, source geometry(Geometry, 4326), mode TEXT, data_range integer[], options text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  import json
+  from cartodb_services.here import HereMapsRoutingIsoline
+  from cartodb_services.metrics import QuotaService
+  from cartodb_services.here.types import geo_polyline_to_multipolygon
+
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  user_routing_config = GD["user_routing_config_{0}".format(username)]
+
+  quota_service = QuotaService(user_routing_config, redis_conn)
+
+  try:
+    client = HereMapsRoutingIsoline(user_routing_config.heremaps_app_id, user_routing_config.heremaps_app_code, base_url = HereMapsRoutingIsoline.PRODUCTION_ROUTING_BASE_URL)
+
+    if source:
+      lat = plpy.execute("SELECT ST_Y('%s') AS lat" % source)[0]['lat']
+      lon = plpy.execute("SELECT ST_X('%s') AS lon" % source)[0]['lon']
+      source_str = 'geo!%f,%f' % (lat, lon)
+    else:
+      source_str = None
+
+    if type == 'isodistance':
+      resp = client.calculate_isodistance(source_str, mode, data_range, options)
+    elif type == 'isochrone':
+      resp = client.calculate_isochrone(source_str, mode, data_range, options)
+
+    if resp:
+      result = []
+      for isoline in resp:
+        data_range_n = isoline['range']
+        polyline = isoline['geom']
+        multipolygon = geo_polyline_to_multipolygon(polyline)
+        result.append([source, data_range_n, multipolygon])
+      quota_service.increment_success_geocoder_use()
+      quota_service.increment_isolines_service_use(len(resp))
+      return result
+    else:
+      quota_service.increment_empty_geocoder_use()
+  except BaseException as e:
+    import sys, traceback
+    type_, value_, traceback_ = sys.exc_info()
+    quota_service.increment_failed_geocoder_use()
+    error_msg = 'There was an error trying to obtain isodistances using here maps geocoder: {0}'.format(e)
+    plpy.notice(traceback.format_tb(traceback_))
+    plpy.error(error_msg)
+  finally:
+    quota_service.increment_total_geocoder_use()
+$$ LANGUAGE plpythonu SECURITY DEFINER;

--- a/server/extension/sql/0.5.0/85_isodistance.sql
+++ b/server/extension/sql/0.5.0/85_isodistance.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isodistance(username TEXT, orgname TEXT, source geometry(Geometry, 4326), mode TEXT, range integer[], options text[] DEFAULT array[]::text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_isolines_config = GD["user_routing_config_{0}".format(username)]
+  type = 'isodistance'
+
+  here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
+  result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
+  isolines = []
+  for element in result:
+    isoline = element['isoline']
+    isoline = isoline.translate(None, "()").split(',')
+    isolines.append(isoline)
+
+  return isolines
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/0.5.0/90_isochrone.sql
+++ b/server/extension/sql/0.5.0/90_isochrone.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isochrone(username TEXT, orgname TEXT, source geometry(Geometry, 4326), mode TEXT, range integer[], options text[] DEFAULT array[]::text[])
+RETURNS SETOF cdb_dataservices_server.isoline AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+  plpy.execute("SELECT cdb_dataservices_server._get_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+  user_isolines_config = GD["user_routing_config_{0}".format(username)]
+  type = 'isochrone'
+
+  here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
+  result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
+  isolines = []
+  for element in result:
+    isoline = element['isoline']
+    isoline = isoline.translate(None, "()").split(',')
+    isolines.append(isoline)
+
+  return isolines
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/0.5.0/99_geocoder_server_user.sql
+++ b/server/extension/sql/0.5.0/99_geocoder_server_user.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT *
+        FROM   pg_catalog.pg_user
+        WHERE  usename = 'geocoder_api') THEN
+
+            CREATE USER geocoder_api;
+    END IF;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA cdb_dataservices_server TO geocoder_api;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO geocoder_api;
+    GRANT USAGE ON SCHEMA cdb_dataservices_server TO geocoder_api;
+    GRANT USAGE ON SCHEMA public TO geocoder_api;
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO geocoder_api;
+END$$;

--- a/server/extension/test/0.5.0/expected/00_install_test.out
+++ b/server/extension/test/0.5.0/expected/00_install_test.out
@@ -1,0 +1,36 @@
+-- Install dependencies
+CREATE EXTENSION postgis;
+CREATE EXTENSION schema_triggers;
+CREATE EXTENSION plpythonu;
+CREATE EXTENSION cartodb;
+CREATE EXTENSION cdb_geocoder;
+-- Install the extension
+CREATE EXTENSION cdb_dataservices_server;
+-- Mock the redis server connection to point to this very test db
+SELECT cartodb.cdb_conf_setconf('redis_metrics_config', '{"sentinel_host": "localhost", "sentinel_port": 26379, "sentinel_master_id": "mymaster", "timeout": 0.1, "redis_db": 5}');
+ cdb_conf_setconf 
+------------------
+ 
+(1 row)
+
+SELECT cartodb.cdb_conf_setconf('redis_metadata_config', '{"sentinel_host": "localhost", "sentinel_port": 26379, "sentinel_master_id": "mymaster", "timeout": 0.1, "redis_db": 5}');
+ cdb_conf_setconf 
+------------------
+ 
+(1 row)
+
+-- Mock the varnish invalidation function
+-- (used by cdb_geocoder tests)
+CREATE OR REPLACE FUNCTION public.cdb_invalidate_varnish(table_name text) RETURNS void AS $$
+BEGIN
+  RETURN;
+END
+$$
+LANGUAGE plpgsql;
+-- Set user quota
+SELECT cartodb.CDB_SetUserQuotaInBytes(0);
+ cdb_setuserquotainbytes 
+-------------------------
+                       0
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/20_street_test.out
+++ b/server/extension/test/0.5.0/expected/20_street_test.out
@@ -1,0 +1,12 @@
+-- Check for namedplaces signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_street_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/30_admin0_test.out
+++ b/server/extension/test/0.5.0/expected/30_admin0_test.out
@@ -1,0 +1,47 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_admin0_polygon('test_user', 'test_orgname', 'Spain');
+ cdb_geocode_admin0_polygon 
+----------------------------
+ 
+(1 row)
+
+-- Insert some dummy synonym
+INSERT INTO admin0_synonyms (name, adm0_a3) VALUES ('Spain', 'ESP');
+-- Insert some dummy geometry to return
+INSERT INTO ne_admin0_v3 (adm0_a3, the_geom) VALUES('ESP', ST_GeomFromText(
+  'POLYGON((-71.1031880899493 42.3152774590236,
+            -71.1031627617667 42.3152960829043,
+            -71.102923838298 42.3149156848307,
+            -71.1031880899493 42.3152774590236))',4326)
+);
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_admin0_polygon('test_user', 'test_orgname', 'Spain');
+                                                                     cdb_geocode_admin0_polygon                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0103000020E61000000100000004000000D0EA37A29AC651C00FD603035B284540FEFCFB379AC651C0C0503E9F5B284540FFDDDD4D96C651C033AC3B284F284540D0EA37A29AC651C00FD603035B284540
+(1 row)
+
+-- Check for admin0 signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin0_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin0_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/40_admin1_test.out
+++ b/server/extension/test/0.5.0/expected/40_admin1_test.out
@@ -1,0 +1,81 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California');
+ cdb_geocode_admin1_polygon 
+----------------------------
+ 
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California', 'United States');
+ cdb_geocode_admin1_polygon 
+----------------------------
+ 
+(1 row)
+
+-- Insert dummy data into country decoder table
+INSERT INTO country_decoder (synonyms, iso3) VALUES (Array['united states'], 'USA');
+-- Insert some dummy data and geometry to return
+INSERT INTO global_province_polygons (synonyms, iso3, the_geom) VALUES (Array['california'], 'USA', ST_GeomFromText(
+  'POLYGON((-71.1031880899493 42.3152774590236,
+            -71.1031627617667 42.3152960829043,
+            -71.102923838298 42.3149156848307,
+            -71.1031880899493 42.3152774590236))',4326)
+);
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California');
+                                                                     cdb_geocode_admin1_polygon                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0103000020E61000000100000004000000D0EA37A29AC651C00FD603035B284540FEFCFB379AC651C0C0503E9F5B284540FFDDDD4D96C651C033AC3B284F284540D0EA37A29AC651C00FD603035B284540
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California', 'United States');
+                                                                     cdb_geocode_admin1_polygon                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0103000020E61000000100000004000000D0EA37A29AC651C00FD603035B284540FEFCFB379AC651C0C0503E9F5B284540FFDDDD4D96C651C033AC3B284F284540D0EA37A29AC651C00FD603035B284540
+(1 row)
+
+-- Check for admin1 signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/50_namedplaces_test.out
+++ b/server/extension/test/0.5.0/expected/50_namedplaces_test.out
@@ -1,0 +1,136 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx');
+ cdb_geocode_namedplace_point 
+------------------------------
+ 
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Spain');
+ cdb_geocode_namedplace_point 
+------------------------------
+ 
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Valencia', 'Spain');
+ cdb_geocode_namedplace_point 
+------------------------------
+ 
+(1 row)
+
+-- Insert dummy data into points table
+INSERT INTO global_cities_points_limited (geoname_id, name, iso2, admin1, admin2, population, lowername, the_geom) VALUES (3128760, 'Elche', 'ES', 'Valencia', 'AL', 34534, 'elche', ST_GeomFromText(
+  'POINT(0.6983 39.26787)',4326)
+);
+-- Insert dummy data into alternates table
+INSERT INTO global_cities_alternates_limited (geoname_id, name, preferred, lowername, admin1_geonameid, iso2, admin1, the_geom) VALUES (3128760, 'Elx', true, 'elx', '000000', 'ES', 'Valencia', ST_GeomFromText(
+  'POINT(0.6983 39.26787)',4326)
+);
+-- Insert dummy data into country decoder table
+INSERT INTO country_decoder (synonyms, iso2) VALUES (Array['spain'], 'ES');
+-- Insert dummy data into admin1 decoder table
+INSERT INTO admin1_decoder (admin1, synonyms, iso2) VALUES ('Valencia', Array['valencia', 'Valencia'], 'ES');
+-- This should return the point inserted above
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Spain');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche', 'Spain');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Valencia', 'Spain');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche', 'valencia', 'Spain');
+            cdb_geocode_namedplace_point            
+----------------------------------------------------
+ 0101000020E6100000637FD93D7958E63F2ECA6C9049A24340
+(1 row)
+
+-- Check for namedplaces signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/60_postalcodes_test.out
+++ b/server/extension/test/0.5.0/expected/60_postalcodes_test.out
@@ -1,0 +1,163 @@
+-- Make sure dbs are clean
+DELETE FROM global_postal_code_points;
+DELETE FROM global_postal_code_polygons;
+DELETE FROM country_decoder;
+DELETE FROM available_services;
+DELETE FROM admin0_synonyms;
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204');
+ cdb_geocode_postalcode_point 
+------------------------------
+ 
+(1 row)
+
+-- Insert dummy data into ip_address_locations
+INSERT INTO global_postal_code_points (the_geom, iso3, postal_code, postal_code_num) VALUES (
+  '0101000020E61000000000000000E040408036B47414764840',
+  'ESP',
+  '03204',
+  3204
+);
+INSERT INTO global_postal_code_polygons (the_geom, iso3, postal_code, postal_code_num) VALUES (
+  '0106000020E610000001000000010300000001000000040000000000000000E000C01F383D7839B740400000000000E000C0AA3C0EDE220F3B4000000000004812404FB7FCCD04893D400000000000E000C01F383D7839B74040',
+  'ESP',
+  '03204',
+  3204
+);
+INSERT INTO country_decoder (iso3, synonyms) VALUES (
+  'ESP',
+  Array['spain', 'Spain', 'ESP']
+);
+INSERT INTO available_services (adm0_a3, admin0, postal_code_points, postal_code_polygons) VALUES (
+  'ESP',
+  't',
+  't',
+  't'
+);
+INSERT INTO admin0_synonyms (adm0_a3, name, name_, rank) VALUES (
+  'ESP',
+  'Spain',
+  'spain',
+  3
+);
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204');
+            cdb_geocode_postalcode_point            
+----------------------------------------------------
+ 0101000020E61000000000000000E040408036B47414764840
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204', 'spain');
+            cdb_geocode_postalcode_point            
+----------------------------------------------------
+ 0101000020E61000000000000000E040408036B47414764840
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_polygon('test_user', 'test_org', '03204');
+                                                                            cdb_geocode_postalcode_polygon                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0106000020E610000001000000010300000001000000040000000000000000E000C01F383D7839B740400000000000E000C0AA3C0EDE220F3B4000000000004812404FB7FCCD04893D400000000000E000C01F383D7839B74040
+(1 row)
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_polygon('test_user', 'test_org', '03204', 'spain');
+                                                                            cdb_geocode_postalcode_polygon                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0106000020E610000001000000010300000001000000040000000000000000E000C01F383D7839B740400000000000E000C0AA3C0EDE220F3B4000000000004812404FB7FCCD04893D400000000000E000C01F383D7839B74040
+(1 row)
+
+-- Clean dbs
+DELETE FROM global_postal_code_points;
+DELETE FROM global_postal_code_polygons;
+DELETE FROM country_decoder;
+DELETE FROM available_services;
+DELETE FROM admin0_synonyms;
+-- Check for namedplaces signatures (point and polygon)
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/70_ips_test.out
+++ b/server/extension/test/0.5.0/expected/70_ips_test.out
@@ -1,0 +1,40 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_ipaddress_point('test_user', 'test_orgname', '0.0.0.0');
+ cdb_geocode_ipaddress_point 
+-----------------------------
+ 
+(1 row)
+
+-- Insert dummy data into ip_address_locations
+INSERT INTO ip_address_locations VALUES ('::ffff:0.0.0.0'::inet, (ST_SetSRID(ST_MakePoint('40.40', '3.71'), 4326)));
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_ipaddress_point('test_user', 'test_orgname', '0.0.0.0');
+            cdb_geocode_ipaddress_point             
+----------------------------------------------------
+ 0101000020E61000003333333333334440AE47E17A14AE0D40
+(1 row)
+
+-- Check for namedplaces signatures (point and polygon)
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_ipaddress_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+ exists 
+--------
+ t
+(1 row)
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_ipaddress_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/85_isodistance_test.out
+++ b/server/extension/test/0.5.0/expected/85_isodistance_test.out
@@ -1,0 +1,12 @@
+-- Check for isodistance signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_isodistance'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, geometry, text, integer[], text[]');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/90_isochrone_test.out
+++ b/server/extension/test/0.5.0/expected/90_isochrone_test.out
@@ -1,0 +1,12 @@
+-- Check for isochrone signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_isochrone'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, geometry, text, integer[], text[]');
+ exists 
+--------
+ t
+(1 row)
+

--- a/server/extension/test/0.5.0/expected/99_remove_geocoder_api_user_test.out
+++ b/server/extension/test/0.5.0/expected/99_remove_geocoder_api_user_test.out
@@ -1,0 +1,5 @@
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA cdb_dataservices_server FROM geocoder_api;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM geocoder_api;
+REVOKE USAGE ON SCHEMA cdb_dataservices_server FROM geocoder_api;
+REVOKE USAGE ON SCHEMA public FROM geocoder_api;
+REVOKE SELECT ON ALL TABLES IN SCHEMA public FROM geocoder_api;

--- a/server/extension/test/0.5.0/sql/00_install_test.sql
+++ b/server/extension/test/0.5.0/sql/00_install_test.sql
@@ -1,0 +1,25 @@
+-- Install dependencies
+CREATE EXTENSION postgis;
+CREATE EXTENSION schema_triggers;
+CREATE EXTENSION plpythonu;
+CREATE EXTENSION cartodb;
+CREATE EXTENSION cdb_geocoder;
+
+-- Install the extension
+CREATE EXTENSION cdb_dataservices_server;
+
+-- Mock the redis server connection to point to this very test db
+SELECT cartodb.cdb_conf_setconf('redis_metrics_config', '{"sentinel_host": "localhost", "sentinel_port": 26379, "sentinel_master_id": "mymaster", "timeout": 0.1, "redis_db": 5}');
+SELECT cartodb.cdb_conf_setconf('redis_metadata_config', '{"sentinel_host": "localhost", "sentinel_port": 26379, "sentinel_master_id": "mymaster", "timeout": 0.1, "redis_db": 5}');
+
+-- Mock the varnish invalidation function
+-- (used by cdb_geocoder tests)
+CREATE OR REPLACE FUNCTION public.cdb_invalidate_varnish(table_name text) RETURNS void AS $$
+BEGIN
+  RETURN;
+END
+$$
+LANGUAGE plpgsql;
+
+-- Set user quota
+SELECT cartodb.CDB_SetUserQuotaInBytes(0);

--- a/server/extension/test/0.5.0/sql/20_street_test.sql
+++ b/server/extension/test/0.5.0/sql/20_street_test.sql
@@ -1,0 +1,7 @@
+-- Check for namedplaces signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_street_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text, text, text');

--- a/server/extension/test/0.5.0/sql/30_admin0_test.sql
+++ b/server/extension/test/0.5.0/sql/30_admin0_test.sql
@@ -1,0 +1,32 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_admin0_polygon('test_user', 'test_orgname', 'Spain');
+
+-- Insert some dummy synonym
+INSERT INTO admin0_synonyms (name, adm0_a3) VALUES ('Spain', 'ESP');
+
+-- Insert some dummy geometry to return
+INSERT INTO ne_admin0_v3 (adm0_a3, the_geom) VALUES('ESP', ST_GeomFromText(
+  'POLYGON((-71.1031880899493 42.3152774590236,
+            -71.1031627617667 42.3152960829043,
+            -71.102923838298 42.3149156848307,
+            -71.1031880899493 42.3152774590236))',4326)
+);
+
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_admin0_polygon('test_user', 'test_orgname', 'Spain');
+
+-- Check for admin0 signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin0_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin0_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');

--- a/server/extension/test/0.5.0/sql/40_admin1_test.sql
+++ b/server/extension/test/0.5.0/sql/40_admin1_test.sql
@@ -1,0 +1,48 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California');
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California', 'United States');
+
+-- Insert dummy data into country decoder table
+INSERT INTO country_decoder (synonyms, iso3) VALUES (Array['united states'], 'USA');
+
+-- Insert some dummy data and geometry to return
+INSERT INTO global_province_polygons (synonyms, iso3, the_geom) VALUES (Array['california'], 'USA', ST_GeomFromText(
+  'POLYGON((-71.1031880899493 42.3152774590236,
+            -71.1031627617667 42.3152960829043,
+            -71.102923838298 42.3149156848307,
+            -71.1031880899493 42.3152774590236))',4326)
+);
+
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California');
+SELECT cdb_dataservices_server.cdb_geocode_admin1_polygon('test_user', 'test_orgname', 'California', 'United States');
+
+-- Check for admin1 signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_admin1_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');

--- a/server/extension/test/0.5.0/sql/50_namedplaces_test.sql
+++ b/server/extension/test/0.5.0/sql/50_namedplaces_test.sql
@@ -1,0 +1,72 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Spain');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Valencia', 'Spain');
+
+-- Insert dummy data into points table
+INSERT INTO global_cities_points_limited (geoname_id, name, iso2, admin1, admin2, population, lowername, the_geom) VALUES (3128760, 'Elche', 'ES', 'Valencia', 'AL', 34534, 'elche', ST_GeomFromText(
+  'POINT(0.6983 39.26787)',4326)
+);
+
+-- Insert dummy data into alternates table
+INSERT INTO global_cities_alternates_limited (geoname_id, name, preferred, lowername, admin1_geonameid, iso2, admin1, the_geom) VALUES (3128760, 'Elx', true, 'elx', '000000', 'ES', 'Valencia', ST_GeomFromText(
+  'POINT(0.6983 39.26787)',4326)
+);
+
+-- Insert dummy data into country decoder table
+INSERT INTO country_decoder (synonyms, iso2) VALUES (Array['spain'], 'ES');
+
+-- Insert dummy data into admin1 decoder table
+INSERT INTO admin1_decoder (admin1, synonyms, iso2) VALUES ('Valencia', Array['valencia', 'Valencia'], 'ES');
+
+-- This should return the point inserted above
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Spain');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche', 'Spain');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elx', 'Valencia', 'Spain');
+SELECT cdb_dataservices_server.cdb_geocode_namedplace_point('test_user', 'test_orgname', 'Elche', 'valencia', 'Spain');
+
+-- Check for namedplaces signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_namedplace_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');

--- a/server/extension/test/0.5.0/sql/60_postalcodes_test.sql
+++ b/server/extension/test/0.5.0/sql/60_postalcodes_test.sql
@@ -1,0 +1,117 @@
+-- Make sure dbs are clean
+DELETE FROM global_postal_code_points;
+DELETE FROM global_postal_code_polygons;
+DELETE FROM country_decoder;
+DELETE FROM available_services;
+DELETE FROM admin0_synonyms;
+
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204');
+
+-- Insert dummy data into ip_address_locations
+INSERT INTO global_postal_code_points (the_geom, iso3, postal_code, postal_code_num) VALUES (
+  '0101000020E61000000000000000E040408036B47414764840',
+  'ESP',
+  '03204',
+  3204
+);
+
+INSERT INTO global_postal_code_polygons (the_geom, iso3, postal_code, postal_code_num) VALUES (
+  '0106000020E610000001000000010300000001000000040000000000000000E000C01F383D7839B740400000000000E000C0AA3C0EDE220F3B4000000000004812404FB7FCCD04893D400000000000E000C01F383D7839B74040',
+  'ESP',
+  '03204',
+  3204
+);
+
+INSERT INTO country_decoder (iso3, synonyms) VALUES (
+  'ESP',
+  Array['spain', 'Spain', 'ESP']
+);
+
+INSERT INTO available_services (adm0_a3, admin0, postal_code_points, postal_code_polygons) VALUES (
+  'ESP',
+  't',
+  't',
+  't'
+);
+
+INSERT INTO admin0_synonyms (adm0_a3, name, name_, rank) VALUES (
+  'ESP',
+  'Spain',
+  'spain',
+  3
+);
+
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204');
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_point('test_user', 'test_org', '03204', 'spain');
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_polygon('test_user', 'test_org', '03204');
+
+SELECT cdb_dataservices_server.cdb_geocode_postalcode_polygon('test_user', 'test_org', '03204', 'spain');
+
+-- Clean dbs
+DELETE FROM global_postal_code_points;
+DELETE FROM global_postal_code_polygons;
+DELETE FROM country_decoder;
+DELETE FROM available_services;
+DELETE FROM admin0_synonyms;
+
+-- Check for namedplaces signatures (point and polygon)
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_postalcode_polygon'
+              AND oidvectortypes(p.proargtypes)  = 'text, text');

--- a/server/extension/test/0.5.0/sql/70_ips_test.sql
+++ b/server/extension/test/0.5.0/sql/70_ips_test.sql
@@ -1,0 +1,24 @@
+-- Check that the public function is callable, even with no data
+-- It should return NULL
+SELECT cdb_dataservices_server.cdb_geocode_ipaddress_point('test_user', 'test_orgname', '0.0.0.0');
+
+-- Insert dummy data into ip_address_locations
+INSERT INTO ip_address_locations VALUES ('::ffff:0.0.0.0'::inet, (ST_SetSRID(ST_MakePoint('40.40', '3.71'), 4326)));
+
+-- This should return the polygon inserted above
+SELECT cdb_dataservices_server.cdb_geocode_ipaddress_point('test_user', 'test_orgname', '0.0.0.0');
+
+-- Check for namedplaces signatures (point and polygon)
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_geocode_ipaddress_point'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, text');
+
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = '_cdb_geocode_ipaddress_point'
+              AND oidvectortypes(p.proargtypes)  = 'text');

--- a/server/extension/test/0.5.0/sql/85_isodistance_test.sql
+++ b/server/extension/test/0.5.0/sql/85_isodistance_test.sql
@@ -1,0 +1,7 @@
+-- Check for isodistance signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_isodistance'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, geometry, text, integer[], text[]');

--- a/server/extension/test/0.5.0/sql/90_isochrone_test.sql
+++ b/server/extension/test/0.5.0/sql/90_isochrone_test.sql
@@ -1,0 +1,7 @@
+-- Check for isochrone signatures
+SELECT exists(SELECT *
+              FROM pg_proc p
+              INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+              WHERE ns.nspname = 'cdb_dataservices_server'
+              AND proname = 'cdb_isochrone'
+              AND oidvectortypes(p.proargtypes)  = 'text, text, geometry, text, integer[], text[]');

--- a/server/extension/test/0.5.0/sql/99_remove_geocoder_api_user_test.sql
+++ b/server/extension/test/0.5.0/sql/99_remove_geocoder_api_user_test.sql
@@ -1,0 +1,5 @@
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA cdb_dataservices_server FROM geocoder_api;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM geocoder_api;
+REVOKE USAGE ON SCHEMA cdb_dataservices_server FROM geocoder_api;
+REVOKE USAGE ON SCHEMA public FROM geocoder_api;
+REVOKE SELECT ON ALL TABLES IN SCHEMA public FROM geocoder_api;

--- a/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
+++ b/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
@@ -6,28 +6,26 @@ class RedisConnection:
 
     REDIS_DEFAULT_USER_DB = 5
     REDIS_DEFAULT_TIMEOUT = 2  #seconds
-    REDIS_SENTINEL_DEFAULT_PORT = 26379
-    REDIS_DEFAULT_PORT = 6379
+    #REDIS_SENTINEL_DEFAULT_PORT = 26379
+    #REDIS_DEFAULT_PORT = 6379
 
-    def __init__(self, sentinel_host, sentinel_port, sentinel_master_id,
-                 redis_host, redis_db=REDIS_DEFAULT_USER_DB, **kwargs):
-        self.sentinel_host = sentinel_host
-        self.sentinel_port = sentinel_port
-        self.sentinel_master_id = sentinel_master_id
+    def __init__(self, sentinel_master_id, redis_host, redis_port,
+                 redis_db=REDIS_DEFAULT_USER_DB, **kwargs):
         self.redis_host = redis_host
+        self.redis_port = redis_port
+        self.sentinel_master_id = sentinel_master_id
         self.timeout = kwargs['timeout'] if 'timeout' in kwargs else self.REDIS_DEFAULT_TIMEOUT
         self.redis_db = redis_db
-        self.redis_port = self.REDIS_DEFAULT_PORT
 
     def redis_connection(self):
         return self.__create_redis_connection()
 
     def __create_redis_connection(self):
-        if (self.sentinel_host == None) or (self.sentinel_master_id == None):
+        if self.sentinel_master_id == None:
             return StrictRedis(host=self.redis_host, port=self.redis_port, db=self.redis_db)
         else:
-            sentinel = Sentinel([(self.sentinel_host,
-                                  self.REDIS_SENTINEL_DEFAULT_PORT)],
+            sentinel = Sentinel([(self.redis_host,
+                                  self.redis_port)],
                                 socket_timeout=self.timeout)
             return sentinel.master_for(
                 self.sentinel_master_id,

--- a/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
+++ b/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
@@ -1,4 +1,5 @@
 from redis.sentinel import Sentinel
+from redis import StrictRedis
 
 
 class RedisConnection:
@@ -6,24 +7,30 @@ class RedisConnection:
     REDIS_DEFAULT_USER_DB = 5
     REDIS_DEFAULT_TIMEOUT = 2  #seconds
     REDIS_SENTINEL_DEFAULT_PORT = 26379
+    REDIS_DEFAULT_PORT = 6379
 
     def __init__(self, sentinel_host, sentinel_port, sentinel_master_id,
-                 redis_db=REDIS_DEFAULT_USER_DB, **kwargs):
+                 redis_host, redis_db=REDIS_DEFAULT_USER_DB, **kwargs):
         self.sentinel_host = sentinel_host
         self.sentinel_port = sentinel_port
         self.sentinel_master_id = sentinel_master_id
+        self.redis_host = redis_host
         self.timeout = kwargs['timeout'] if 'timeout' in kwargs else self.REDIS_DEFAULT_TIMEOUT
         self.redis_db = redis_db
+        self.redis_port = self.REDIS_DEFAULT_PORT
 
     def redis_connection(self):
         return self.__create_redis_connection()
 
     def __create_redis_connection(self):
-        sentinel = Sentinel([(self.sentinel_host,
-                              self.REDIS_SENTINEL_DEFAULT_PORT)],
-                            socket_timeout=self.timeout)
-        return sentinel.master_for(
-            self.sentinel_master_id,
-            socket_timeout=self.timeout,
-            db=self.redis_db
-        )
+        if (self.sentinel_host == None) or (self.sentinel_master_id == None):
+            return StrictRedis(host=self.redis_host, port=self.redis_port, db=self.redis_db)
+        else:
+            sentinel = Sentinel([(self.sentinel_host,
+                                  self.REDIS_SENTINEL_DEFAULT_PORT)],
+                                socket_timeout=self.timeout)
+            return sentinel.master_for(
+                self.sentinel_master_id,
+                socket_timeout=self.timeout,
+                db=self.redis_db
+            )


### PR DESCRIPTION
If sentinel_host or sentinel_cluster_id is not provided it will try to
connect with a redis_host parameter

This way we can support deploying simpler local servers environments like a development one.

Redis command can be run in the same way from a strictredis connection instance or a sentinel one through master_for method, so the type of connection returned by python should be totally transparent for the extension.

It's a proof of concept. If it's ok I should probably add a test for this new case and we should decide in what case a strictredis connection is chosen over of sentinel one. At this moment strictredis connection is chosen when sentinel_host or sentinel_cluster_id are None. Either if we choose to introduce this support or not it would be a good a idea to add some params checking in the python lib connection method.

/cc @rafatower @ethervoid 