### PR TITLE
Block google services users to use isolines functions

### DIFF
--- a/server/extension/cdb_dataservices_server--0.3.0--0.4.0.sql
+++ b/server/extension/cdb_dataservices_server--0.3.0--0.4.0.sql
@@ -87,6 +87,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isodistance'
 
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
+
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
   isolines = []
@@ -105,6 +108,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isochrone'
+
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
 
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])

--- a/server/extension/cdb_dataservices_server--0.4.0.sql
+++ b/server/extension/cdb_dataservices_server--0.4.0.sql
@@ -866,6 +866,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isodistance'
 
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
+
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
   isolines = []
@@ -883,6 +886,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isochrone'
+
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
 
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])

--- a/server/extension/sql/0.4.0/85_isodistance.sql
+++ b/server/extension/sql/0.4.0/85_isodistance.sql
@@ -6,6 +6,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isodistance'
 
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
+
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
   isolines = []

--- a/server/extension/sql/0.4.0/90_isochrone.sql
+++ b/server/extension/sql/0.4.0/90_isochrone.sql
@@ -6,6 +6,9 @@ RETURNS SETOF cdb_dataservices_server.isoline AS $$
   user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
   type = 'isochrone'
 
+  if user_isolines_config.google_services_user:
+    plpy.error('This service is not available for google service users.')
+
   here_plan = plpy.prepare("SELECT cdb_dataservices_server._cdb_here_routing_isolines($1, $2, $3, $4, $5, $6, $7) as isoline; ", ["text", "text", "text", "geometry(Geometry, 4326)", "text", "integer[]", "text[]"])
   result = plpy.execute(here_plan, [username, orgname, type, source, mode, range, options])
   isolines = []

--- a/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
@@ -32,7 +32,7 @@ class IsolinesRoutingConfig(ServiceConfig):
 
     ROUTING_CONFIG_KEYS = ['here_isolines_quota', 'soft_here_isolines_limit',
                            'period_end_date', 'username', 'orgname',
-                           'heremaps_app_id', 'heremaps_app_code']
+                           'heremaps_app_id', 'heremaps_app_code', 'geocoder_type']
     NOKIA_APP_ID_KEY = 'heremaps_app_id'
     NOKIA_APP_CODE_KEY = 'heremaps_app_code'
     QUOTA_KEY = 'here_isolines_quota'
@@ -40,6 +40,8 @@ class IsolinesRoutingConfig(ServiceConfig):
     USERNAME_KEY = 'username'
     ORGNAME_KEY = 'orgname'
     PERIOD_END_DATE = 'period_end_date'
+    GEOCODER_TYPE_KEY = 'geocoder_type'
+    GOOGLE_GEOCODER = 'google'
 
     def __init__(self, redis_connection, username, orgname=None,
                  heremaps_app_id=None, heremaps_app_code=None):
@@ -74,6 +76,7 @@ class IsolinesRoutingConfig(ServiceConfig):
             user_config[self.PERIOD_END_DATE] = org_config[self.PERIOD_END_DATE]
 
     def __parse_config(self, filtered_config):
+        self._geocoder_type = filtered_config[self.GEOCODER_TYPE_KEY].lower()
         self._isolines_quota = float(filtered_config[self.QUOTA_KEY])
         self._period_end_date = date_parse(filtered_config[self.PERIOD_END_DATE])
         if filtered_config[self.SOFT_LIMIT_KEY].lower() == 'true':
@@ -106,6 +109,10 @@ class IsolinesRoutingConfig(ServiceConfig):
     @property
     def heremaps_app_code(self):
         return self._heremaps_app_code
+
+    @property
+    def google_services_user(self):
+        return self._geocoder_type == self.GOOGLE_GEOCODER
 
 
 class InternalGeocoderConfig(ServiceConfig):


### PR DESCRIPTION
Due to some TOS restrictions, google services users must not use
the HERE services which includes the isolines functions.

Please @rafatower check this out