### PR TITLE
added note about zcta under postal codes generator section

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -9,6 +9,7 @@ The isoline functions provide a way to generate isolines in terms of distance an
 ## Documentation
 
 * [Quickstart](quickstart.md)
-* [General concepts](general_concepts.md)
-* [Geocoding functions](geocoding_functions.md)
-* [Isoline functions](isoline_functions.md)
+* [General Concepts](general_concepts.md)
+* [Geocoding Functions](geocoding_functions.md)
+* [Isoline Functions](isoline_functions.md)
+* [Quota Information](quota_information.md)

--- a/doc/general_concepts.md
+++ b/doc/general_concepts.md
@@ -1,4 +1,4 @@
-# General concepts
+# General Concepts
 
 The Data Services API offers geocoding and isoline services on top of the CartoDB SQL API by means of a set of functions. Each one of these functions is oriented to one kind of operation and returns the corresponding geometry (a `polygon` or a `point`), according to the input information.
 

--- a/doc/geocoding_functions.md
+++ b/doc/geocoding_functions.md
@@ -181,7 +181,7 @@ UPDATE {tablename} SET the_geom = cdb_geocode_namedplace_point({city_column}, {p
 
 The following functions provide a postal code geocoding service that can be used to obtain points or polygon results. The postal code polygon geocoder covers the United States, France, Australia and Canada; a request for a different country will return an empty response.
 
-**Note:** For the USA, US Census [Zip Code Tabulation Areas](https://www.census.gov/geo/reference/zctas.html) (ZCTA) are used to reference geocodes for USPS postal codes service areas.
+**Note:** For the USA, US Census [Zip Code Tabulation Areas](https://www.census.gov/geo/reference/zctas.html) (ZCTA) are used to reference geocodes for USPS postal codes service areas. See the [FAQs](http://docs.cartodb.com/faqs/datasets-and-data/#why-does-cartodb-use-census-bureau-zctas-and-not-usps-zip-codes-for-postal-codes) about datasets and data for details.
 
 ### cdb_geocode_postalcode_polygon(_postal_code text, country_name text_)
 

--- a/doc/geocoding_functions.md
+++ b/doc/geocoding_functions.md
@@ -1,4 +1,4 @@
-# Geocoding functions
+# Geocoding Functions
 
 The following geocoding functions are available, grouped by categories.
 
@@ -181,6 +181,8 @@ UPDATE {tablename} SET the_geom = cdb_geocode_namedplace_point({city_column}, {p
 
 The following functions provide a postal code geocoding service that can be used to obtain points or polygon results. The postal code polygon geocoder covers the United States, France, Australia and Canada; a request for a different country will return an empty response.
 
+**Note:** For the USA, US Census [Zip Code Tabulation Areas](https://www.census.gov/geo/reference/zctas.html) (ZCTA) are used to reference geocodes for USPS postal codes service areas.
+
 ### cdb_geocode_postalcode_polygon(_postal_code text, country_name text_)
 
 #### Arguments
@@ -207,8 +209,6 @@ SELECT cdb_geocode_postalcode_polygon('11211', 'USA')
 ```bash
 UPDATE {tablename} SET the_geom = cdb_geocode_postalcode_polygon({postal_code_column}, 'USA')
 ```
-
-**Note:** For the USA, US Census ZCTAs are considered.
 
 ### cdb_geocode_postalcode_point(_code text, country_name text_)
 

--- a/doc/isoline_functions.md
+++ b/doc/isoline_functions.md
@@ -1,4 +1,4 @@
-# Isoline functions
+# Isoline Functions
 
 The following functions provide an isolines generator service based on time or distance. This service uses the isolines service defined for the user (currently, only the Here isolines service is available).
 

--- a/doc/quota_information.md
+++ b/doc/quota_information.md
@@ -1,4 +1,4 @@
-# Quota information
+# Quota Information
 
 **This Data Services API provides functions which are subject to quota limitations, and extra fees may apply**. Please check our [terms and conditions](https://cartodb.com/terms/).
 


### PR DESCRIPTION
For [Docs issue#726](https://github.com/CartoDB/docs/issues/726).

@ztephm , I was told you found a reference to zcta in the docs that was vague. Does this note help clarify? Let me know if you were talking about a different section of the docs?