### PR TITLE
Use retry on timeout flag for Redis connections

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
+++ b/server/lib/python/cartodb_services/cartodb_services/tools/redis_tools.py
@@ -16,14 +16,13 @@ class RedisConnection:
             sentinel = Sentinel([(self._config.host,
                                   self._config.port)],
                                 socket_timeout=self._config.timeout)
-            return sentinel.master_for(
-                self._config.sentinel_id,
-                socket_timeout=self._config.timeout,
-                db=self._config.db
-            )
+            return sentinel.master_for(self._config.sentinel_id,
+                                       socket_timeout=self._config.timeout,
+                                       db=self._config.db,
+                                       retry_on_timeout=True)
         else:
             conn = StrictRedis(host=self._config.host, port=self._config.port,
-                               db=self._config.db,
+                               db=self._config.db, retry_on_timeout=True,
                                socket_timeout=self._config.timeout)
             return conn
 

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.4.2',
+    version='0.4.3',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
In order to avoid some fails due some high load peaks in our Redis
databases, we are going to active this flag that retries 1 more time
in case it receives a socket.Timeout error while reading or connecting