### PR TITLE
Geocoder functions should be provider agnostic

### DIFF
--- a/server/extension/sql/20_geocode_street.sql
+++ b/server/extension/sql/20_geocode_street.sql
@@ -97,7 +97,10 @@ RETURNS Geometry AS $$
 
   try:
     geocoder = MapzenGeocoder(user_geocoder_config.mapzen_app_key)
-    coordinates = geocoder.geocode(searchtext=searchtext, country=country)
+    country_iso3 = None
+    if country:
+      country_iso3 = country_to_iso3(country)
+    coordinates = geocoder.geocode(searchtext=searchtext, country=country_iso3)
     if coordinates:
       quota_service.increment_success_service_use()
       plan = plpy.prepare("SELECT ST_SetSRID(ST_MakePoint($1, $2), 4326); ", ["double precision", "double precision"])

--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/geocoder.py
@@ -17,8 +17,8 @@ class MapzenGeocoder:
         self._url = base_url
 
     @qps_retry
-    def geocode(self, searchtext, country=None):
-        request_params = self._build_requests_parameters(searchtext, country)
+    def geocode(self, searchtext, city=None, state_province=None, country=None):
+        request_params = self._build_requests_parameters(searchtext, city, state_province, country)
         response = requests.get(self._url, params=request_params)
         if response.status_code == requests.codes.ok:
             return self.__parse_response(response.text)
@@ -27,14 +27,25 @@ class MapzenGeocoder:
         else:
             response.raise_for_status()
 
-    def _build_requests_parameters(self, searchtext, country=None):
+    def _build_requests_parameters(self, searchtext, city=None,
+                                   state_province=None, country=None):
         request_params = {}
-        request_params['text'] = searchtext
+        search_string = self._build_search_text(searchtext, city, state_province)
+        request_params['text'] = search_string
         request_params['layers'] = 'address'
         request_params['api_key'] = self._app_key
         if country:
             request_params['boundary.country'] = country
         return request_params
+
+    def _build_search_text(self, searchtext, city, state_province):
+        search_string = searchtext
+        if city:
+            search_string = "{0}, {1}".format(search_string, city)
+        if state_province:
+            search_string = "{0}, {1}".format(search_string, state_province)
+
+        return search_string
 
     def __parse_response(self, response):
         try:

--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
@@ -18,3 +18,17 @@ def polyline_to_linestring(polyline):
         geometry = None
 
     return geometry
+
+def country_to_iso3(country):
+    """ Convert country to its iso3 code """
+    try:
+        country_plan = plpy.prepare("SELECT adm0_a3 as iso3 FROM admin0_synonyms WHERE lower(regexp_replace($1, " \
+                                    "'[^a-zA-Z\u00C0-\u00ff]+', '', 'g'))::text = name_; ", ['text'])
+        country_result = plpy.execute(country_plan, [country], 1)
+        if country_result:
+            return country_result[0]['iso3']
+        else:
+            return None
+    except BaseException as e:
+        plpy.warning("Can't get the iso3 code from {0}: {1}".format(country, e))
+        return None

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.4.3',
+    version='0.4.4',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
- [x] We have to make the geocoding functions agnostic so we need to transform the country passed when using mapzen to isocode 3
- [x] When the user pass the country and the state parameters, are concatenated to the search string.

@iriberri please take a look