### PR TITLE
New release task for Makefile

### DIFF
--- a/server/extension/Makefile
+++ b/server/extension/Makefile
@@ -2,39 +2,47 @@
 # Once a version is released, it is not meant to be changed. E.g: once version 0.0.1 is out, it SHALL NOT be changed.
 EXTENSION = cdb_dataservices_server
 EXTVERSION = $(shell grep default_version $(EXTENSION).control | sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
-
 # The new version to be generated from templates
+SED = sed
+ERB = erb
+REPLACEMENTS = -i 's/$(EXTVERSION)/$(NEW_VERSION)/g'
 NEW_EXTENSION_ARTIFACT = $(EXTENSION)--$(EXTVERSION).sql
-OLD_VERSIONS = $(wildcard old_versions/*.sql)
+
+REGRESS = $(notdir $(basename $(wildcard test/sql/*test.sql)))
+TEST_DIR = test/
+REGRESS_OPTS = --inputdir='$(TEST_DIR)' --outputdir='$(TEST_DIR)'
 
 # DATA is a special variable used by postgres build infrastructure
 # These are the files to be installed in the server shared dir,
 # for installation from scratch, upgrades and downgrades.
 # @see http://www.postgresql.org/docs/current/static/extend-pgxs.html
-DATA =  $(NEW_EXTENSION_ARTIFACT) \
-  $(OLD_VERSIONS) \
-  cdb_dataservices_server--0.9.0--0.10.0.sql \
-  cdb_dataservices_server--0.10.0--0.9.0.sql
-
-REGRESS = $(notdir $(basename $(wildcard test/sql/*test.sql)))
-TEST_DIR = test/
-REGRESS_OPTS = --inputdir='$(TEST_DIR)' --outputdir='$(TEST_DIR)'
+DATA = $(EXTENSION)--*.sql
+OLD_VERSIONS = $(wildcard old_versions/*.sql)
+SOURCES_DATA_DIR = sql/
+SOURCES_DATA = $(wildcard sql/*.sql)
 
 # postgres build stuff
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
-SOURCES_DATA_DIR = sql/
-
-SOURCES_DATA = $(wildcard sql/*.sql)
-
 $(NEW_EXTENSION_ARTIFACT): $(SOURCES_DATA)
 	rm -f $@
 	cat $(SOURCES_DATA_DIR)/*.sql >> $@
 
+.PHONY: all
 all: $(DATA)
 
+.PHONY: release
+release: $(EXTENSION).control $(SOURCES_DATA)
+	test -n "$(NEW_VERSION)"  # $$NEW_VERSION VARIABLE MISSING. Eg. make release NEW_VERSION=0.x.0
+	mv *.sql old_versions
+	$(SED) $(REPLACEMENTS) $(EXTENSION).control
+	cat $(SOURCES_DATA_DIR)/*.sql > $(EXTENSION)--$(NEW_VERSION).sql
+	$(ERB) version=$(NEW_VERSION) upgrade_downgrade_template.erb > $(EXTENSION)--$(EXTVERSION)--$(NEW_VERSION).sql
+	$(ERB) version=$(EXTVERSION) upgrade_downgrade_template.erb > $(EXTENSION)--$(NEW_VERSION)--$(EXTVERSION).sql
+
 # Only meant for development time, do not use once a version is released
+.PHONY: devclean
 devclean:
 	rm -f $(NEW_EXTENSION_ARTIFACT)

--- a/server/extension/upgrade_downgrade_template.erb
+++ b/server/extension/upgrade_downgrade_template.erb
@@ -1,0 +1,5 @@
+--DO NOT MODIFY THIS FILE, IT IS GENERATED AUTOMATICALLY FROM SOURCES
+-- Complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION cdb_dataservices_server UPDATE TO '<%= version %>'" to load this file. \quit
+
+-- HERE goes your code to upgrade/downgrade


### PR DESCRIPTION
Added new release task in the make file to automate the new version
process:

- Move current version to old_versions folder
- Change .control file to the new version
- Create the complete SQL file for the new version
- Create empty upgrade and downgrade files

To call the new task you should pass the NEWVERSION variable. Eg:

make release NEWVERSION=0.x.0