### PR TITLE
207 fix test if obs search is ok

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,9 +2,11 @@
 This are the automatic integration tests for geocoder api (both client and server)
 
 ### Usage
-In order to execute the tests you have to execute the `run_tests` python script:
+In order to execute the tests you have to execute the `run_tests.py` python script:
 
-``` python run_tests.py [--host=cartodb.com] username api_key```
+```sh
+python run_tests.py [--host=cartodb.com] username api_key
+```
 
 You can define the host where is going to execute the SQL API queries to test the
 geocoder API. By default the value is `cartodb.com` but you can put the host you need.
@@ -19,3 +21,34 @@ This suite of tests test the following parts of the geocoding API through the SQ
 - Postal code functions
 - Ip address functions
 - Street address functions (This will call Heremaps or Google so it will cost you 2 credits)
+- Routing functions
+- Isolines functions
+- Data Observatory functions
+
+
+### How to debug the tests
+You won't be able to plug a debugger when using the `run_test.py` because of the usage of a subprocess and the piping.
+
+You should be aware that some tests require some extra setup (a test table), that you'll need to do on your own in some cases (check the `ImportHelper.import_test_dataset`)
+
+In order to do so, you need to use plain `nosetests` which comes prepared to that.
+
+First, add this to the python test code:
+
+```python
+from nose.tools import set_trace; set_trace()
+```
+
+Secondly, execute just your test with this:
+
+```ssh
+GEOCODER_API_TEST_USERNAME=your_username \
+GEOCODER_API_TEST_API_KEY=your_api_key \
+GEOCODER_API_TEST_TABLE_NAME=your_test_table \
+GEOCODER_API_TEST_HOST=your_target_test_host \
+nosetests --where=integration/ test_data_observatory_functions.py:TestDataObservatoryFunctions.test_if_obs_search_is_ok
+```
+
+(replace the environment variables, test file, class and function according to your needs)
+
+TODO: we need to refactor the test code a little to avoid these hindrances

--- a/test/integration/test_data_observatory_functions.py
+++ b/test/integration/test_data_observatory_functions.py
@@ -129,7 +129,9 @@ class TestDataObservatoryFunctions(TestCase):
             assert_equal(e.message[0], "The api_key must be provided")
 
     def test_if_obs_search_is_ok(self):
-        query = "SELECT id FROM OBS_Search('total_pop') LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
+        sql = "SELECT id FROM OBS_Search('total_pop') WHERE id LIKE 'es.ine%' LIMIT 1;"
+        import urllib
+        query = "{0}&api_key={1}".format(urllib.quote(sql), self.env_variables['api_key'])
         result = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(result['id'], None)
         assert_equal(result['id'], 'es.ine.t1_1')


### PR DESCRIPTION
Make the test_if_obs_search_is_ok a bit more robust by narrowing the
query to exactly what is expected, as suggested by talos.

@iriberri or @jgoizueta  can you please review? (mostly informational)

Notes:
1. I had to add the url quoting to make it work with a percentage sign (`%`) in the sql query.
2. I don't like this patch, the same way I do not like the fact that it's a bit blurred in the test code who's responsible for quoting url params or composing them (I tried to get it fixed in the test helper, but it is a bit messed up).
3. I also dislike the test runner, which makes it pretty hard to plug a debugger in.

So to sum up: we need a quick fix for the integration tests to keep running but also consider improving that code.