### PR TITLE
Fix bug on exception raise for Mapzen geocoder config

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
@@ -144,7 +144,7 @@ class MapzenGeocoderConfig(ServiceConfig):
             self._period_end_date = date_parse(self._redis_config[self.PERIOD_END_DATE])
             self._cost_per_hit = 0
         except Exception as e:
-            raise ConfigException("Malformed config for Mapzen geocoder: {1}".format(key, e))
+            raise ConfigException("Malformed config for Mapzen geocoder: {0}".format(e))
 
     @property
     def service_type(self):


### PR DESCRIPTION
When I was testing the new code I didn't experience any issue with configs as I had it set up correctly, but today I noticed about this. `key` is not defined in that scope at all so I'm editing the tuple a bit.


Please @rafatower take a look. This is what I was mentioning before.