### PR TITLE
Replace all 'area' defaults for "normalize" with NULL. 

### DIFF
--- a/client/renderer/interface.yaml
+++ b/client/renderer/interface.yaml
@@ -147,13 +147,13 @@
   params:
     - { name: geom,  type: "geometry(Geometry, 4326)" }
     - { name: time_span,  type: "text", default: "'2009 - 2013'::text" }
-    - { name: geometry_level, type: text, default: "'\"us.census.tiger\".block_group'::text" }
+    - { name: geometry_level, type: text, default: 'NULL' }
 
 - name: obs_get_segment_snapshot
   return_type: json
   params:
     - { name: geom,  type: "geometry(Geometry, 4326)" }
-    - { name: geometry_level, type: text, default: "'\"us.census.tiger\".census_tract'::text" }
+    - { name: geometry_level, type: text, default: 'NULL' }
 
 - name: obs_getdemographicsnapshot
   return_type: SETOF JSON
@@ -202,7 +202,7 @@
     - { name: geom,  type: "geometry(Geometry, 4326)" }
     - { name: boundary_id, type: text }
     - { name: time_span, type: text, default: 'NULL'}
-    - { name: overlap_type, type: text, default: "'intersects'"}
+    - { name: overlap_type, type: text, default: 'NULL'}
 
 - name: obs_getboundariesbypointandradius
   return_type: TABLE(the_geom geometry, geom_refs text)
@@ -216,7 +216,7 @@
     - { name: radius, type: numeric }
     - { name: boundary_id, type: text }
     - { name: time_span, type: text, default: 'NULL'}
-    - { name: overlap_type, type: text, default: "'intersects'"}
+    - { name: overlap_type, type: text, default: 'NULL'}
 
 - name: obs_getpointsbygeometry
   return_type: TABLE(the_geom geometry, geom_refs text)
@@ -229,7 +229,7 @@
     - { name: geom,  type: "geometry(Geometry, 4326)" }
     - { name: boundary_id, type: text }
     - { name: time_span, type: text, default: 'NULL'}
-    - { name: overlap_type, type: text, default: "'intersects'"}
+    - { name: overlap_type, type: text, default: 'NULL'}
 
 - name: obs_getpointsbypointandradius
   return_type: TABLE(the_geom geometry, geom_refs text)
@@ -243,7 +243,7 @@
     - { name: radius, type: numeric }
     - { name: boundary_id, type: text }
     - { name: time_span, type: text, default: 'NULL'}
-    - { name: overlap_type, type: text, default: "'intersects'"}
+    - { name: overlap_type, type: text, default: 'NULL'}
 
 - name: obs_getmeasure
   return_type: numeric

--- a/client/renderer/interface.yaml
+++ b/client/renderer/interface.yaml
@@ -250,7 +250,7 @@
   params:
     - { name: geom,  type: Geometry }
     - { name: measure_id, type: text }
-    - { name: normalize, type: text, default: "'area'"}
+    - { name: normalize, type: text, default: 'NULL'}
     - { name: boundary_id, type: text, default: 'NULL' }
     - { name: time_span, type: text, default: 'NULL'}
 
@@ -275,7 +275,7 @@
   params:
     - { name: geom,  type: Geometry }
     - { name: name, type: text }
-    - { name: normalize, type: text, default: "'area'"}
+    - { name: normalize, type: text, default: 'NULL'}
     - { name: boundary_id, type: text, default: 'NULL' }
     - { name: time_span, type: text, default: 'NULL'}
 
@@ -291,7 +291,7 @@
   return_type: numeric
   params:
     - { name: geom,  type: Geometry }
-    - { name: normalize, type: text, default: "'area'"}
+    - { name: normalize, type: text, default: 'NULL'}
     - { name: boundary_id, type: text, default: 'NULL' }
     - { name: time_span, type: text, default: 'NULL'}
 

--- a/client/test/expected/90_data_observatory_test.out
+++ b/client/test/expected/90_data_observatory_test.out
@@ -92,7 +92,7 @@ BEGIN
   RETURN QUERY SELECT '0101000020E610000037CB75821A7C52C0BA8784EFFD594440'::geometry as the_geom, '36047048900'::text as geom_refs;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getmeasure (username text, orgname text, geom Geometry, measure_id text, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getmeasure (username text, orgname text, geom Geometry, measure_id text, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;
@@ -122,7 +122,7 @@ BEGIN
   RETURN ret;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getuscensusmeasure (username text, orgname text, geom Geometry, name text, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getuscensusmeasure (username text, orgname text, geom Geometry, name text, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;
@@ -142,7 +142,7 @@ BEGIN
   RETURN ret;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpopulation (username text, orgname text, geom Geometry, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpopulation (username text, orgname text, geom Geometry, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;
@@ -268,7 +268,7 @@ CONTEXT:  PL/pgSQL function obs_getpointsbypointandradius(geometry,numeric,text,
 (1 row)
 
 SELECT obs_getmeasure(ST_SetSRID(ST_Point(-73.936669 , 40.704512), 4326), 'us.census.acs.B01001001'::text);
-NOTICE:  cdb_dataservices_client._obs_getmeasure(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getmeasure invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, us.census.acs.B01001001, area, <NULL>, <NULL>)
+NOTICE:  cdb_dataservices_client._obs_getmeasure(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getmeasure invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, us.census.acs.B01001001, <NULL>, <NULL>, <NULL>)
 CONTEXT:  SQL statement "SELECT cdb_dataservices_client._obs_getmeasure(username, orgname, geom, measure_id, normalize, boundary_id, time_span)"
 PL/pgSQL function obs_getmeasure(geometry,text,text,text,text) line 16 at SQL statement
     obs_getmeasure     
@@ -295,7 +295,7 @@ PL/pgSQL function obs_getcategory(geometry,text,text,text) line 16 at SQL statem
 (1 row)
 
 SELECT obs_getuscensusmeasure(ST_SetSRID(ST_Point(-73.936669 , 40.704512), 4326), 'male population'::text);
-NOTICE:  cdb_dataservices_client._obs_getuscensusmeasure(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getuscensusmeasure invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, male population, area, <NULL>, <NULL>)
+NOTICE:  cdb_dataservices_client._obs_getuscensusmeasure(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getuscensusmeasure invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, male population, <NULL>, <NULL>, <NULL>)
 CONTEXT:  SQL statement "SELECT cdb_dataservices_client._obs_getuscensusmeasure(username, orgname, geom, name, normalize, boundary_id, time_span)"
 PL/pgSQL function obs_getuscensusmeasure(geometry,text,text,text,text) line 16 at SQL statement
  obs_getuscensusmeasure 
@@ -313,7 +313,7 @@ PL/pgSQL function obs_getuscensuscategory(geometry,text,text,text) line 16 at SQ
 (1 row)
 
 SELECT obs_getpopulation(ST_SetSRID(ST_Point(-73.936669 , 40.704512), 4326));
-NOTICE:  cdb_dataservices_client._obs_getpopulation(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpopulation invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, area, <NULL>, <NULL>)
+NOTICE:  cdb_dataservices_client._obs_getpopulation(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpopulation invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, <NULL>, <NULL>, <NULL>)
 CONTEXT:  SQL statement "SELECT cdb_dataservices_client._obs_getpopulation(username, orgname, geom, normalize, boundary_id, time_span)"
 PL/pgSQL function obs_getpopulation(geometry,text,text,text) line 16 at SQL statement
    obs_getpopulation   

--- a/client/test/expected/90_data_observatory_test.out
+++ b/client/test/expected/90_data_observatory_test.out
@@ -71,21 +71,21 @@ BEGIN
   RETURN ret;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getboundariesbypointandradius invoked with params (%, %, %, %, %, %, %)', username, orgname, geom, radius, boundary_id, time_span, overlap_type;
   RETURN QUERY SELECT '0106000020E6100000010000000103000000010000001500000083A3E4D5397C52C09946938B315A44404AED45B41D7C52C0785DBF60375A444099F221A81A7C52C0D0EFFB372F5A4440B9C15087157C52C034643C4A255A4440BB438A01127C52C0DE1CAED51E5A44400FECF82F107C52C0876D8B321B5A4440510FD1E80E7C52C0C4D32B65195A44407FDAA84E077C52C0E0675C38105A444092AD2EA7047C52C08E75711B0D5A4440CF2D7425027C52C0A86DC328085A4440EFFCA204FD7B52C07E384888F259444034BC5983F77B52C0205ED72FD8594440E76F4221027C52C0F3A96395D259444081AD122C0E7C52C00ED6FF39CC594440CB63CDC8207C52C031276893C359444047205ED72F7C52C0287D21E4BC594440BD1C76DF317C52C0F8325184D4594440CD1FD3DA347C52C0B0A9F3A8F8594440C72E51BD357C52C0C3651536035A444043024697377C52C028999CDA195A444083A3E4D5397C52C09946938B315A4440'::geometry as the_geom, '36047048900'::text as geom_refs;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getpointsbygeometry invoked with params (%, %, %, %, %, %)', username, orgname, geom, boundary_id, time_span, overlap_type;
   RETURN QUERY SELECT '0101000020E610000037CB75821A7C52C0BA8784EFFD594440'::geometry as the_geom, '36047048900'::text as geom_refs;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getpointsbypointandradius invoked with params (%, %, %, %, %, %, %)', username, orgname, geom, radius, boundary_id, time_span, overlap_type;
@@ -166,7 +166,7 @@ BEGIN
   RETURN QUERY SELECT 'us.census.tiger.place'::text as boundary_id, 'Incorporated places are those reported to the Census Bureau as legally in existence as of January 1, 2010, as reported in the latest Boundary and Annexation Survey (BAS), under the laws of their respective states.'::text as description, '2014'::text as timespan, 'obs_7c9493c41fa8f4bd178ab993ea3d5891c1977667'::text as tablename;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getboundariesbygeometry invoked with params (%, %, %, %, %, %)', username, orgname, geom, boundary_id, time_span, overlap_type;
@@ -236,7 +236,7 @@ PL/pgSQL function obs_getboundarybyid(text,text,text) line 16 at SQL statement
 (1 row)
 
 SELECT obs_getboundariesbygeometry(ST_MakeEnvelope(-73.9452409744, 40.6988851644, -73.9280319214, 40.7101254524, 4326), 'us.census.tiger.census_tract'::text);
-NOTICE:  cdb_dataservices_client._obs_getboundariesbygeometry(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getboundariesbygeometry invoked with params (test_user, <NULL>, 0103000020E61000000100000005000000C7F8FFD37E7C52C0F860AE1175594440C7F8FFD37E7C52C0BF0E0D64E55A4440A70300E0647B52C0BF0E0D64E55A4440A70300E0647B52C0F860AE1175594440C7F8FFD37E7C52C0F860AE1175594440, us.census.tiger.census_tract, <NULL>, intersects)
+NOTICE:  cdb_dataservices_client._obs_getboundariesbygeometry(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getboundariesbygeometry invoked with params (test_user, <NULL>, 0103000020E61000000100000005000000C7F8FFD37E7C52C0F860AE1175594440C7F8FFD37E7C52C0BF0E0D64E55A4440A70300E0647B52C0BF0E0D64E55A4440A70300E0647B52C0F860AE1175594440C7F8FFD37E7C52C0F860AE1175594440, us.census.tiger.census_tract, <NULL>, <NULL>)
 CONTEXT:  PL/pgSQL function obs_getboundariesbygeometry(geometry,text,text,text) line 16 at RETURN QUERY
                                                                                                                                                                                                                                                                                                                                                                                                                                     obs_getboundariesbygeometry                                                                                                                                                                                                                                                                                                                                                                                                                                     
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -244,7 +244,7 @@ CONTEXT:  PL/pgSQL function obs_getboundariesbygeometry(geometry,text,text,text)
 (1 row)
 
 SELECT obs_getboundariesbypointandradius(ST_SetSRID(ST_Point(-73.936669 , 40.704512), 4326), 500, 'us.census.tiger.census_tract'::text);
-NOTICE:  cdb_dataservices_client._obs_getboundariesbypointandradius(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getboundariesbypointandradius invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, 500, us.census.tiger.census_tract, <NULL>, intersects)
+NOTICE:  cdb_dataservices_client._obs_getboundariesbypointandradius(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getboundariesbypointandradius invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, 500, us.census.tiger.census_tract, <NULL>, <NULL>)
 CONTEXT:  PL/pgSQL function obs_getboundariesbypointandradius(geometry,numeric,text,text,text) line 16 at RETURN QUERY
                                                                                                                                                                                                                                                                                                                                                                  obs_getboundariesbypointandradius                                                                                                                                                                                                                                                                                                                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -252,7 +252,7 @@ CONTEXT:  PL/pgSQL function obs_getboundariesbypointandradius(geometry,numeric,t
 (1 row)
 
 SELECT obs_getpointsbygeometry(ST_MakeEnvelope(-73.9452409744, 40.6988851644, -73.9280319214, 40.7101254524, 4326), 'us.census.tiger.census_tract'::text);
-NOTICE:  cdb_dataservices_client._obs_getpointsbygeometry(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpointsbygeometry invoked with params (test_user, <NULL>, 0103000020E61000000100000005000000C7F8FFD37E7C52C0F860AE1175594440C7F8FFD37E7C52C0BF0E0D64E55A4440A70300E0647B52C0BF0E0D64E55A4440A70300E0647B52C0F860AE1175594440C7F8FFD37E7C52C0F860AE1175594440, us.census.tiger.census_tract, <NULL>, intersects)
+NOTICE:  cdb_dataservices_client._obs_getpointsbygeometry(6): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpointsbygeometry invoked with params (test_user, <NULL>, 0103000020E61000000100000005000000C7F8FFD37E7C52C0F860AE1175594440C7F8FFD37E7C52C0BF0E0D64E55A4440A70300E0647B52C0BF0E0D64E55A4440A70300E0647B52C0F860AE1175594440C7F8FFD37E7C52C0F860AE1175594440, us.census.tiger.census_tract, <NULL>, <NULL>)
 CONTEXT:  PL/pgSQL function obs_getpointsbygeometry(geometry,text,text,text) line 16 at RETURN QUERY
                      obs_getpointsbygeometry                      
 ------------------------------------------------------------------
@@ -260,7 +260,7 @@ CONTEXT:  PL/pgSQL function obs_getpointsbygeometry(geometry,text,text,text) lin
 (1 row)
 
 SELECT obs_getpointsbypointandradius(ST_SetSRID(ST_Point(-73.936669 , 40.704512), 4326), 500::numeric, 'us.census.tiger.census_tract'::text);
-NOTICE:  cdb_dataservices_client._obs_getpointsbypointandradius(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpointsbypointandradius invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, 500, us.census.tiger.census_tract, <NULL>, intersects)
+NOTICE:  cdb_dataservices_client._obs_getpointsbypointandradius(7): [contrib_regression] REMOTE NOTICE: cdb_dataservices_server.obs_getpointsbypointandradius invoked with params (test_user, <NULL>, 0101000020E6100000548B8862F27B52C0DDD1FF722D5A4440, 500, us.census.tiger.census_tract, <NULL>, <NULL>)
 CONTEXT:  PL/pgSQL function obs_getpointsbypointandradius(geometry,numeric,text,text,text) line 16 at RETURN QUERY
                   obs_getpointsbypointandradius                   
 ------------------------------------------------------------------

--- a/client/test/sql/90_data_observatory_test.sql
+++ b/client/test/sql/90_data_observatory_test.sql
@@ -80,7 +80,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getboundariesbypointandradius invoked with params (%, %, %, %, %, %, %)', username, orgname, geom, radius, boundary_id, time_span, overlap_type;
@@ -88,7 +88,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getpointsbygeometry invoked with params (%, %, %, %, %, %)', username, orgname, geom, boundary_id, time_span, overlap_type;
@@ -96,7 +96,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpointsbypointandradius (username text, orgname text, geom geometry(Geometry, 4326), radius numeric, boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getpointsbypointandradius invoked with params (%, %, %, %, %, %, %)', username, orgname, geom, radius, boundary_id, time_span, overlap_type;
@@ -186,7 +186,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT 'intersects')
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getboundariesbygeometry (username text, orgname text, geom geometry(Geometry, 4326), boundary_id text, time_span text DEFAULT NULL, overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
 BEGIN
   RAISE NOTICE 'cdb_dataservices_server.obs_getboundariesbygeometry invoked with params (%, %, %, %, %, %)', username, orgname, geom, boundary_id, time_span, overlap_type;

--- a/client/test/sql/90_data_observatory_test.sql
+++ b/client/test/sql/90_data_observatory_test.sql
@@ -104,7 +104,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getmeasure (username text, orgname text, geom Geometry, measure_id text, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getmeasure (username text, orgname text, geom Geometry, measure_id text, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;
@@ -137,7 +137,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getuscensusmeasure (username text, orgname text, geom Geometry, name text, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getuscensusmeasure (username text, orgname text, geom Geometry, name text, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;
@@ -159,7 +159,7 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpopulation (username text, orgname text, geom Geometry, normalize text DEFAULT 'area', boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.obs_getpopulation (username text, orgname text, geom Geometry, normalize text DEFAULT NULL, boundary_id text DEFAULT NULL, time_span text DEFAULT NULL)
 RETURNS numeric AS $$
 DECLARE
   ret numeric;

--- a/server/extension/sql/110_data_observatory_augmentation.sql
+++ b/server/extension/sql/110_data_observatory_augmentation.sql
@@ -231,7 +231,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetMeasure(
   orgname TEXT,
   geom geometry(Geometry, 4326),
   measure_id TEXT,
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$
@@ -244,7 +244,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetMeasure(
   orgname TEXT,
   geom geometry(Geometry, 4326),
   measure_id TEXT,
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$
@@ -339,7 +339,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetUSCensusMeasure(
   orgname TEXT,
   geom geometry(Geometry, 4326),
   name TEXT,
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$
@@ -352,7 +352,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetUSCensusMeasure(
   orgname TEXT,
   geom geometry(Geometry, 4326),
   name TEXT,
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$
@@ -446,7 +446,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetPopulation(
   username TEXT,
   orgname TEXT,
   geom geometry(Geometry, 4326),
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$
@@ -458,7 +458,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetPopulation(
   username TEXT,
   orgname TEXT,
   geom geometry(Geometry, 4326),
-  normalize TEXT DEFAULT 'area',
+  normalize TEXT DEFAULT NULL,
   boundary_id TEXT DEFAULT NULL,
   time_span TEXT DEFAULT NULL)
 RETURNS NUMERIC AS $$

--- a/server/extension/sql/120_data_observatory_geometries.sql
+++ b/server/extension/sql/120_data_observatory_geometries.sql
@@ -157,7 +157,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetBoundariesByGeometry(
   geom geometry(Point, 4326),
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type text DEFAULT 'intersects')
+  overlap_type text DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   CONNECT cdb_dataservices_server._obs_server_conn_str(username, orgname);
   SELECT * FROM cdb_observatory.OBS_GetBoundariesByGeometry(geom, boundary_id, time_span, overlap_type);
@@ -169,7 +169,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetBoundariesByGeometry(
   geom geometry(Point, 4326),
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   from cartodb_services.metrics import QuotaService
   from cartodb_services.tools import Logger,LoggerConfig
@@ -216,7 +216,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetBoundariesByPointAndR
   radius NUMERIC,
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   CONNECT cdb_dataservices_server._obs_server_conn_str(username, orgname);
   SELECT * FROM cdb_observatory.OBS_GetBoundariesByPointAndRadius(geom, radius, boundary_id, time_span, overlap_type);
@@ -229,7 +229,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetBoundariesByPointAndRa
   radius NUMERIC,
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   from cartodb_services.metrics import QuotaService
   from cartodb_services.tools import Logger,LoggerConfig
@@ -275,7 +275,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetPointsByGeometry(
   geom geometry(Point, 4326),
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   CONNECT cdb_dataservices_server._obs_server_conn_str(username, orgname);
   SELECT * FROM cdb_observatory.OBS_GetPointsByGeometry(geom, boundary_id, time_span, overlap_type);
@@ -287,7 +287,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetPointsByGeometry(
   geom geometry(Point, 4326),
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   from cartodb_services.metrics import QuotaService
   from cartodb_services.tools import Logger,LoggerConfig
@@ -334,7 +334,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server._OBS_GetPointsByPointAndRadiu
   radius NUMERIC,
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   CONNECT cdb_dataservices_server._obs_server_conn_str(username, orgname);
   SELECT * FROM cdb_observatory.OBS_GetPointsByPointAndRadius(geom, radius, boundary_id, time_span, overlap_type);
@@ -347,7 +347,7 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_server.OBS_GetPointsByPointAndRadius
   radius NUMERIC,
   boundary_id TEXT,
   time_span TEXT DEFAULT NULL,
-  overlap_type TEXT DEFAULT 'intersects')
+  overlap_type TEXT DEFAULT NULL)
 RETURNS TABLE(the_geom geometry, geom_refs text) AS $$
   from cartodb_services.metrics import QuotaService
   from cartodb_services.tools import Logger,LoggerConfig


### PR DESCRIPTION
 Fixes #235.

CR @iriberri ?  I think I caught everything, but might have missed some.

After this is done, the analysis pipeline should have the desired default behavior when obtaining the measure for a polygon (which is to find the actual number for that polygon instead of a rate).