### PR TITLE
302 expose quotas

### DIFF
--- a/server/extension/sql/200_quotas.sql
+++ b/server/extension/sql/200_quotas.sql
@@ -37,3 +37,20 @@ RETURNS integer AS $$
   else:
     raise 'not implemented'
 $$ LANGUAGE plpythonu;
+
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_soft_limit(
+  username TEXT,
+  orgname TEXT,
+  service TEXT)
+RETURNS boolean AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+
+  if service == 'isolines':
+    plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+    user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
+    return user_isolines_config.soft_isolines_limit
+  else:
+    raise 'not implemented'
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/200_quotas.sql
+++ b/server/extension/sql/200_quotas.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_monthly_quota(
+  username TEXT,
+  orgname TEXT,
+  service TEXT)
+RETURNS integer AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+
+  if service == 'isolines':
+    plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+    user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
+    return user_isolines_config.isolines_quota
+  else:
+    raise 'not implemented'
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/200_quotas.sql
+++ b/server/extension/sql/200_quotas.sql
@@ -13,3 +13,27 @@ RETURNS integer AS $$
   else:
     raise 'not implemented'
 $$ LANGUAGE plpythonu;
+
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_remaining_quota(
+  username TEXT,
+  orgname TEXT,
+  service TEXT)
+RETURNS integer AS $$
+  from datetime import date
+  from cartodb_services.metrics.user import UserMetricsService
+
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+
+  if service == 'isolines':
+    plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+    user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
+    monthly_quota = user_isolines_config.isolines_quota
+
+    user_service = UserMetricsService(user_isolines_config, redis_conn)
+    current_used = user_service.used_quota(user_isolines_config.service_type, date.today())
+    return monthly_quota - current_used
+  else:
+    raise 'not implemented'
+$$ LANGUAGE plpythonu;

--- a/server/extension/sql/200_quotas.sql
+++ b/server/extension/sql/200_quotas.sql
@@ -54,3 +54,20 @@ RETURNS boolean AS $$
   else:
     raise 'not implemented'
 $$ LANGUAGE plpythonu;
+
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_provider(
+  username TEXT,
+  orgname TEXT,
+  service TEXT)
+RETURNS TEXT AS $$
+  plpy.execute("SELECT cdb_dataservices_server._connect_to_redis('{0}')".format(username))
+  redis_conn = GD["redis_connection_{0}".format(username)]['redis_metrics_connection']
+
+  if service == 'isolines':
+    plpy.execute("SELECT cdb_dataservices_server._get_isolines_routing_config({0}, {1})".format(plpy.quote_nullable(username), plpy.quote_nullable(orgname)))
+    user_isolines_config = GD["user_isolines_routing_config_{0}".format(username)]
+    return user_isolines_config.provider
+  else:
+    raise 'not implemented'
+$$ LANGUAGE plpythonu;

--- a/server/lib/python/cartodb_services/README.md
+++ b/server/lib/python/cartodb_services/README.md
@@ -29,12 +29,12 @@ NOTE: a system installation is required at present because the library is meant 
 
 
 ## Running the unit tests
-Just run `nosetests`
+Just run `nosetests test/`
 ```shell
-$ nosetests
-.................................................
+$ nosetests test/
+......................................................................................................
 ----------------------------------------------------------------------
-Ran 49 tests in 0.131s
+Ran 102 tests in 0.122s
 
 OK
 ```

--- a/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
@@ -94,7 +94,7 @@ class ObservatorySnapshotConfig(DataObservatoryConfig):
             self._soft_limit = False
         self._monthly_quota = 0
         if self.QUOTA_KEY in self._redis_config:
-            self._monthly_quota = float(self._redis_config[self.QUOTA_KEY])
+            self._monthly_quota = int(self._redis_config[self.QUOTA_KEY])
         self._connection_str = self._db_config.data_observatory_connection_str
 
     @property
@@ -118,7 +118,7 @@ class ObservatoryConfig(DataObservatoryConfig):
             self._soft_limit = False
         self._monthly_quota = 0
         if self.QUOTA_KEY in self._redis_config:
-            self._monthly_quota = float(self._redis_config[self.QUOTA_KEY])
+            self._monthly_quota = int(self._redis_config[self.QUOTA_KEY])
         self._connection_str = self._db_config.data_observatory_connection_str
 
     @property
@@ -218,7 +218,7 @@ class IsolinesRoutingConfig(ServiceConfig):
         self._geocoder_provider = filtered_config[self.GEOCODER_PROVIDER_KEY].lower()
         self._period_end_date = date_parse(filtered_config[self.PERIOD_END_DATE])
         if self._isolines_provider == self.HEREMAPS_PROVIDER:
-            self._isolines_quota = float(filtered_config[self.QUOTA_KEY])
+            self._isolines_quota = int(filtered_config[self.QUOTA_KEY])
             self._heremaps_app_id = db_config.heremaps_isolines_app_id
             self._heremaps_app_code = db_config.heremaps_isolines_app_code
             if filtered_config[self.SOFT_LIMIT_KEY].lower() == 'true':
@@ -361,7 +361,7 @@ class GeocoderConfig(ServiceConfig):
             self._geocoder_provider = filtered_config[self.GEOCODER_PROVIDER].lower()
         else:
             self._geocoder_provider = self.DEFAULT_PROVIDER
-        self._geocoding_quota = float(filtered_config[self.QUOTA_KEY])
+        self._geocoding_quota = int(filtered_config[self.QUOTA_KEY])
         self._period_end_date = date_parse(filtered_config[self.PERIOD_END_DATE])
         if filtered_config[self.SOFT_LIMIT_KEY].lower() == 'true':
             self._soft_geocoding_limit = True

--- a/server/lib/python/cartodb_services/cartodb_services/metrics/user.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/user.py
@@ -88,11 +88,11 @@ class UserMetricsService:
             redis_prefix = self.__parse_redis_prefix(key_prefix, entity_name,
                                                      service, metric, date)
             score = self._redis_connection.zscore(redis_prefix, date.day)
-            aggregated_metric += score if score else 0
+            aggregated_metric += int(score) if score else 0
             zero_padded_day = date.strftime(self.DAY_OF_MONTH_ZERO_PADDED)
             if str(date.day) != zero_padded_day:
                 score = self._redis_connection.zscore(redis_prefix, zero_padded_day)
-                aggregated_metric += score if score else 0
+                aggregated_metric += int(score) if score else 0
 
         return aggregated_metric
 


### PR DESCRIPTION
Early review request. Things done here:
- Added functions to check:
  - monthly quota allowance, 
  - remaining quota for the current billing period,
  - soft limit, 
  - provider
- Modified the config and metrics service to return values as integers

Things to do:
- extend to the rest of services
- add the client's part
- add tests
- integrate into analysis pre-checks

@jgoizueta and @ethervoid can you please take a quick look? mostly interested in how you find the API and how it fits into the rest of the codebase.

From the top of my head: best interface to deal with soft limits? maybe just instead of  remaining quota expose the used quota?