### PR TITLE
317 timeouts patch

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/isochrones.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/isochrones.py
@@ -13,7 +13,7 @@ class MapzenIsochrones:
     BASE_URL = 'https://matrix.mapzen.com/isochrone'
     READ_TIMEOUT = 60
     CONNECT_TIMEOUT = 10
-    MAX_RETRIES = 3
+    MAX_RETRIES = 1
 
     ACCEPTED_MODES = {
         "walk": "pedestrian",
@@ -25,7 +25,7 @@ class MapzenIsochrones:
         self._url = base_url
         self._logger = logger
 
-    @qps_retry
+    @qps_retry(qps=7)
     def isochrone(self, locations, costing, ranges):
         request_params = self._parse_request_params(locations, costing,
                                                     ranges)

--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/qps.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/qps.py
@@ -55,7 +55,7 @@ class QPSService:
 
     def retry(self, first_request_time, retry_count):
         elapsed = datetime.now() - first_request_time
-        if elapsed.microseconds  > (self._retry_timeout * 1000.0):
+        if elapsed.microseconds  > (self._retry_timeout * 1000.0 * 1000.0):
             raise TimeoutException()
 
         # inverse qps * (1.5 ^ i) is an increased sleep time of 1.5x per

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.12.1',
+    version='0.12.2',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
This changeset:
- fixes an issue with QPS retry timeouts: comparing microseconds with miliseconds
- tweaks a couple of params of the retries:
  - the qps value is set to the actual one (used for the exponential backoff delay calculation)
  - sets the requests library retries to 1, to avoid compulsive retries from the library at a lower level

@ethervoid please review whenever you have a chance. I'm deploying this straight away and then we can continue discussion in the issue #317 