### PR TITLE
314 exception safe public funcs

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,6 +2,7 @@ results/
 regression.diffs
 regression.out
 20_public_functions.sql
+25_exception_safe_private_functions.sql
 30_plproxy_functions.sql
 90_grant_execute.sql
 cdb_geocoder_client--0.0.1.sql

--- a/client/Makefile
+++ b/client/Makefile
@@ -57,9 +57,11 @@ all: $(DATA)
 .PHONY: release
 release: $(EXTENSION).control $(SOURCES_DATA)
 	test -n "$(NEW_VERSION)"  # $$NEW_VERSION VARIABLE MISSING. Eg. make release NEW_VERSION=0.x.0
-	mv *.sql old_versions
+	git mv *.sql old_versions
 	$(SED) $(REPLACEMENTS) $(EXTENSION).control
+	git add $(EXTENSION).control
 	cat $(SOURCES_DATA_DIR)/*.sql > $(EXTENSION)--$(NEW_VERSION).sql
+	git add $(EXTENSION)--$(NEW_VERSION).sql
 	$(ERB) version=$(NEW_VERSION) upgrade_downgrade_template.erb > $(EXTENSION)--$(EXTVERSION)--$(NEW_VERSION).sql
 	$(ERB) version=$(EXTVERSION) upgrade_downgrade_template.erb > $(EXTENSION)--$(NEW_VERSION)--$(EXTVERSION).sql
 

--- a/client/renderer/templates/25_exception_safe_private_functions.erb
+++ b/client/renderer/templates/25_exception_safe_private_functions.erb
@@ -1,8 +1,8 @@
 --
--- Exception-safe public DataServices API function
+-- Exception-safe private DataServices API function
 --
 
-CREATE OR REPLACE FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>_exception_safe (<%= params_with_type_and_default.join(' ,') %>)
+CREATE OR REPLACE FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>_exception_safe (<%= params_with_type_and_default.join(' ,') %>)
 RETURNS <%= return_type %> AS $$
 DECLARE
   <% if not multi_row %>ret <%= return_type %>;<% end %>

--- a/client/renderer/templates/25_exception_safe_private_functions.erb
+++ b/client/renderer/templates/25_exception_safe_private_functions.erb
@@ -8,6 +8,9 @@ DECLARE
   <% if not multi_row %>ret <%= return_type %>;<% end %>
   username text;
   orgname text;
+  _returned_sqlstate TEXT;
+  _message_text TEXT;
+  _pg_exception_context TEXT;
 BEGIN
   IF session_user = 'publicuser' OR session_user ~ 'cartodb_publicuser_*' THEN
     RAISE EXCEPTION 'The api_key must be provided';
@@ -27,10 +30,6 @@ BEGIN
         RAISE WARNING 'whatever';
     END;
   <% elsif multi_field %>
-    DECLARE
-      _returned_sqlstate TEXT;
-      _message_text TEXT;
-      _pg_exception_context TEXT;
     BEGIN
       SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
       RETURN ret;

--- a/client/renderer/templates/25_exception_safe_private_functions.erb
+++ b/client/renderer/templates/25_exception_safe_private_functions.erb
@@ -27,7 +27,10 @@ BEGIN
       SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
     EXCEPTION
       WHEN OTHERS THEN
-        RAISE WARNING 'whatever';
+        GET STACKED DIAGNOSTICS _returned_sqlstate = RETURNED_SQLSTATE,
+                                _message_text = MESSAGE_TEXT,
+                                _pg_exception_context = PG_EXCEPTION_CONTEXT;
+        RAISE WARNING USING ERRCODE = _returned_sqlstate, MESSAGE = _message_text, DETAIL = _pg_exception_context;
     END;
   <% elsif multi_field %>
     BEGIN
@@ -47,7 +50,10 @@ BEGIN
       RETURN ret;
     EXCEPTION
       WHEN OTHERS THEN
-        RAISE WARNING 'whatever';
+        GET STACKED DIAGNOSTICS _returned_sqlstate = RETURNED_SQLSTATE,
+                                _message_text = MESSAGE_TEXT,
+                                _pg_exception_context = PG_EXCEPTION_CONTEXT;
+        RAISE WARNING USING ERRCODE = _returned_sqlstate, MESSAGE = _message_text, DETAIL = _pg_exception_context;
         RETURN ret;
     END;
   <% end %>

--- a/client/renderer/templates/25_exception_safe_public_functions.erb
+++ b/client/renderer/templates/25_exception_safe_public_functions.erb
@@ -27,8 +27,14 @@ BEGIN
         RAISE WARNING 'whatever';
     END;
   <% elsif multi_field %>
-    SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
-    RETURN ret;
+    BEGIN
+      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
+      RETURN ret;
+    EXCEPTION
+      WHEN OTHERS THEN
+        RAISE WARNING 'whatever';
+        RETURN ret;
+    END;
   <% else %>
     BEGIN
       SELECT <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;

--- a/client/renderer/templates/25_exception_safe_public_functions.erb
+++ b/client/renderer/templates/25_exception_safe_public_functions.erb
@@ -1,0 +1,36 @@
+--
+-- Exception-safe public DataServices API function
+--
+
+CREATE OR REPLACE FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>_exception_safe (<%= params_with_type_and_default.join(' ,') %>)
+RETURNS <%= return_type %> AS $$
+DECLARE
+  <% if not multi_row %>ret <%= return_type %>;<% end %>
+  username text;
+  orgname text;
+BEGIN
+  IF session_user = 'publicuser' OR session_user ~ 'cartodb_publicuser_*' THEN
+    RAISE EXCEPTION 'The api_key must be provided';
+  END IF;
+  SELECT u, o INTO username, orgname FROM <%= DATASERVICES_CLIENT_SCHEMA %>._cdb_entity_config() AS (u text, o text);
+  -- JSON value stored "" is taken as literal
+  IF username IS NULL OR username = '' OR username = '""' THEN
+    RAISE EXCEPTION 'Username is a mandatory argument, check it out';
+  END IF;
+  BEGIN
+    <% if multi_row %>
+      RETURN QUERY
+      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
+    <% elsif multi_field %>
+      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
+      RETURN ret;
+    <% else %>
+      SELECT <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
+      RETURN ret;
+    <% end %>
+  EXCEPTION
+    WHEN OTHERS THEN
+      RAISE WARNING 'whatever';
+  END;
+END;
+$$ LANGUAGE 'plpgsql' SECURITY DEFINER;

--- a/client/renderer/templates/25_exception_safe_public_functions.erb
+++ b/client/renderer/templates/25_exception_safe_public_functions.erb
@@ -17,20 +17,22 @@ BEGIN
   IF username IS NULL OR username = '' OR username = '""' THEN
     RAISE EXCEPTION 'Username is a mandatory argument, check it out';
   END IF;
-  BEGIN
-    <% if multi_row %>
-      RETURN QUERY
-      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
-    <% elsif multi_field %>
-      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
-      RETURN ret;
-    <% else %>
+
+  <% if multi_row %>
+    RETURN QUERY
+    SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
+  <% elsif multi_field %>
+    SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
+    RETURN ret;
+  <% else %>
+    BEGIN
       SELECT <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
       RETURN ret;
-    <% end %>
-  EXCEPTION
-    WHEN OTHERS THEN
-      RAISE WARNING 'whatever';
-  END;
+    EXCEPTION
+      WHEN OTHERS THEN
+        RAISE WARNING 'whatever';
+        RETURN ret;
+    END;
+  <% end %>
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;

--- a/client/renderer/templates/25_exception_safe_public_functions.erb
+++ b/client/renderer/templates/25_exception_safe_public_functions.erb
@@ -19,8 +19,13 @@ BEGIN
   END IF;
 
   <% if multi_row %>
-    RETURN QUERY
-    SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
+    BEGIN
+      RETURN QUERY
+      SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>);
+    EXCEPTION
+      WHEN OTHERS THEN
+        RAISE WARNING 'whatever';
+    END;
   <% elsif multi_field %>
     SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
     RETURN ret;

--- a/client/renderer/templates/25_exception_safe_public_functions.erb
+++ b/client/renderer/templates/25_exception_safe_public_functions.erb
@@ -27,12 +27,19 @@ BEGIN
         RAISE WARNING 'whatever';
     END;
   <% elsif multi_field %>
+    DECLARE
+      _returned_sqlstate TEXT;
+      _message_text TEXT;
+      _pg_exception_context TEXT;
     BEGIN
       SELECT * FROM <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>(<%= ['username', 'orgname'].concat(params).join(', ') %>) INTO ret;
       RETURN ret;
     EXCEPTION
       WHEN OTHERS THEN
-        RAISE WARNING 'whatever';
+        GET STACKED DIAGNOSTICS _returned_sqlstate = RETURNED_SQLSTATE,
+                                _message_text = MESSAGE_TEXT,
+                                _pg_exception_context = PG_EXCEPTION_CONTEXT;
+        RAISE WARNING USING ERRCODE = _returned_sqlstate, MESSAGE = _message_text, DETAIL = _pg_exception_context;
         RETURN ret;
     END;
   <% else %>

--- a/client/renderer/templates/90_grant_execute.erb
+++ b/client/renderer/templates/90_grant_execute.erb
@@ -1,1 +1,2 @@
 GRANT EXECUTE ON FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>(<%= params_with_type.join(', ') %>) TO publicuser;
+GRANT EXECUTE ON FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>_exception_safe(<%= params_with_type.join(', ') %>) TO publicuser;

--- a/client/renderer/templates/90_grant_execute.erb
+++ b/client/renderer/templates/90_grant_execute.erb
@@ -1,2 +1,2 @@
 GRANT EXECUTE ON FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>(<%= params_with_type.join(', ') %>) TO publicuser;
-GRANT EXECUTE ON FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>.<%= name %>_exception_safe(<%= params_with_type.join(', ') %>) TO publicuser;
+GRANT EXECUTE ON FUNCTION <%= DATASERVICES_CLIENT_SCHEMA %>._<%= name %>_exception_safe(<%= params_with_type.join(', ') %>) TO publicuser;

--- a/client/test/expected/25_exception_safe_private_functions_test.out
+++ b/client/test/expected/25_exception_safe_private_functions_test.out
@@ -1,5 +1,6 @@
+SET client_min_messages TO warning;
 SET search_path TO public,cartodb,cdb_dataservices_client;
--- Mock the server function to fail
+-- Mock the server functions to raise exceptions
 CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point (username text, orgname text, searchtext text, city text DEFAULT NULL, state_province text DEFAULT NULL, country text DEFAULT NULL)
 RETURNS Geometry AS $$
 BEGIN
@@ -7,9 +8,15 @@ BEGIN
   RETURN NULL;
 END;
 $$ LANGUAGE 'plpgsql';
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isodistance(username text, orgname text, source geometry, mode text, range integer[], options text[] DEFAULT ARRAY[]::text[])
+RETURNS SETOF isoline AS $$
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+END;
+$$ LANGUAGE 'plpgsql';
 -- Use regular user role
 SET ROLE test_regular_user;
--- Exercise the public and the proxied function
+-- Exercise the exception safe and the proxied functions
 SELECT _cdb_geocode_street_point_exception_safe('One street, 1');
 WARNING:  cdb_dataservices_client._cdb_geocode_street_point(6): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
 DETAIL:  SQL statement "SELECT cdb_dataservices_client._cdb_geocode_street_point(username, orgname, searchtext, city, state_province, country)"
@@ -18,4 +25,11 @@ PL/pgSQL function _cdb_geocode_street_point_exception_safe(text,text,text,text) 
 ------------------------------------------
  
 (1 row)
+
+SELECT the_geom FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
+WARNING:  cdb_dataservices_client._cdb_isodistance(6): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
+DETAIL:  PL/pgSQL function _cdb_isodistance_exception_safe(geometry,text,integer[],text[]) line 21 at RETURN QUERY
+ the_geom 
+----------
+(0 rows)
 

--- a/client/test/expected/25_exception_safe_private_functions_test.out
+++ b/client/test/expected/25_exception_safe_private_functions_test.out
@@ -1,0 +1,21 @@
+SET search_path TO public,cartodb,cdb_dataservices_client;
+-- Mock the server function to fail
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point (username text, orgname text, searchtext text, city text DEFAULT NULL, state_province text DEFAULT NULL, country text DEFAULT NULL)
+RETURNS Geometry AS $$
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+  RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+-- Use regular user role
+SET ROLE test_regular_user;
+-- Exercise the public and the proxied function
+SELECT _cdb_geocode_street_point_exception_safe('One street, 1');
+WARNING:  cdb_dataservices_client._cdb_geocode_street_point(6): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
+DETAIL:  SQL statement "SELECT cdb_dataservices_client._cdb_geocode_street_point(username, orgname, searchtext, city, state_province, country)"
+PL/pgSQL function _cdb_geocode_street_point_exception_safe(text,text,text,text) line 21 at SQL statement
+ _cdb_geocode_street_point_exception_safe 
+------------------------------------------
+ 
+(1 row)
+

--- a/client/test/expected/25_exception_safe_private_functions_test.out
+++ b/client/test/expected/25_exception_safe_private_functions_test.out
@@ -14,6 +14,18 @@ BEGIN
   RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
 END;
 $$ LANGUAGE 'plpgsql';
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_route_point_to_point (username text, orgname text, origin geometry(Point, 4326), destination geometry(Point, 4326), mode TEXT, options text[] DEFAULT ARRAY[]::text[], units text DEFAULT 'kilometers')
+RETURNS cdb_dataservices_client.simple_route AS $$
+DECLARE 
+  ret cdb_dataservices_client.simple_route;
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+
+  -- This code shall never be reached
+  SELECT NULL, 5.33, 100 INTO ret;
+  RETURN ret;
+END;
+$$ LANGUAGE 'plpgsql';
 -- Use regular user role
 SET ROLE test_regular_user;
 -- Exercise the exception safe and the proxied functions
@@ -32,4 +44,13 @@ DETAIL:  PL/pgSQL function _cdb_isodistance_exception_safe(geometry,text,integer
  the_geom 
 ----------
 (0 rows)
+
+SELECT shape FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);
+WARNING:  cdb_dataservices_client._cdb_route_point_to_point(7): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
+DETAIL:  SQL statement "SELECT * FROM cdb_dataservices_client._cdb_route_point_to_point(username, orgname, origin, destination, mode, options, units)"
+PL/pgSQL function _cdb_route_point_to_point_exception_safe(geometry,geometry,text,text[],text) line 21 at SQL statement
+ shape 
+-------
+ 
+(1 row)
 

--- a/client/test/expected/25_exception_safe_private_functions_test.out
+++ b/client/test/expected/25_exception_safe_private_functions_test.out
@@ -38,19 +38,19 @@ PL/pgSQL function _cdb_geocode_street_point_exception_safe(text,text,text,text) 
  
 (1 row)
 
-SELECT the_geom FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
+SELECT * FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
 WARNING:  cdb_dataservices_client._cdb_isodistance(6): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
 DETAIL:  PL/pgSQL function _cdb_isodistance_exception_safe(geometry,text,integer[],text[]) line 21 at RETURN QUERY
- the_geom 
-----------
+ center | data_range | the_geom 
+--------+------------+----------
 (0 rows)
 
-SELECT shape FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);
+SELECT * FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);
 WARNING:  cdb_dataservices_client._cdb_route_point_to_point(7): [contrib_regression] REMOTE ERROR: Not enough quota or any other exception whatsoever.
 DETAIL:  SQL statement "SELECT * FROM cdb_dataservices_client._cdb_route_point_to_point(username, orgname, origin, destination, mode, options, units)"
 PL/pgSQL function _cdb_route_point_to_point_exception_safe(geometry,geometry,text,text[],text) line 21 at SQL statement
- shape 
--------
- 
+ shape | length | duration 
+-------+--------+----------
+       |        |         
 (1 row)
 

--- a/client/test/sql/25_exception_safe_private_functions_test.sql
+++ b/client/test/sql/25_exception_safe_private_functions_test.sql
@@ -37,5 +37,5 @@ SET ROLE test_regular_user;
 
 -- Exercise the exception safe and the proxied functions
 SELECT _cdb_geocode_street_point_exception_safe('One street, 1');
-SELECT the_geom FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
-SELECT shape FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);
+SELECT * FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
+SELECT * FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);

--- a/client/test/sql/25_exception_safe_private_functions_test.sql
+++ b/client/test/sql/25_exception_safe_private_functions_test.sql
@@ -1,6 +1,7 @@
+SET client_min_messages TO warning;
 SET search_path TO public,cartodb,cdb_dataservices_client;
 
--- Mock the server function to fail
+-- Mock the server functions to raise exceptions
 CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point (username text, orgname text, searchtext text, city text DEFAULT NULL, state_province text DEFAULT NULL, country text DEFAULT NULL)
 RETURNS Geometry AS $$
 BEGIN
@@ -9,8 +10,17 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_isodistance(username text, orgname text, source geometry, mode text, range integer[], options text[] DEFAULT ARRAY[]::text[])
+RETURNS SETOF isoline AS $$
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+END;
+$$ LANGUAGE 'plpgsql';
+
+
 -- Use regular user role
 SET ROLE test_regular_user;
 
--- Exercise the public and the proxied function
+-- Exercise the exception safe and the proxied functions
 SELECT _cdb_geocode_street_point_exception_safe('One street, 1');
+SELECT the_geom FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);

--- a/client/test/sql/25_exception_safe_private_functions_test.sql
+++ b/client/test/sql/25_exception_safe_private_functions_test.sql
@@ -1,0 +1,16 @@
+SET search_path TO public,cartodb,cdb_dataservices_client;
+
+-- Mock the server function to fail
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_geocode_street_point (username text, orgname text, searchtext text, city text DEFAULT NULL, state_province text DEFAULT NULL, country text DEFAULT NULL)
+RETURNS Geometry AS $$
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+  RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+
+-- Use regular user role
+SET ROLE test_regular_user;
+
+-- Exercise the public and the proxied function
+SELECT _cdb_geocode_street_point_exception_safe('One street, 1');

--- a/client/test/sql/25_exception_safe_private_functions_test.sql
+++ b/client/test/sql/25_exception_safe_private_functions_test.sql
@@ -17,6 +17,20 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE OR REPLACE FUNCTION cdb_dataservices_server.cdb_route_point_to_point (username text, orgname text, origin geometry(Point, 4326), destination geometry(Point, 4326), mode TEXT, options text[] DEFAULT ARRAY[]::text[], units text DEFAULT 'kilometers')
+RETURNS cdb_dataservices_client.simple_route AS $$
+DECLARE 
+  ret cdb_dataservices_client.simple_route;
+BEGIN
+  RAISE EXCEPTION 'Not enough quota or any other exception whatsoever.';
+
+  -- This code shall never be reached
+  SELECT NULL, 5.33, 100 INTO ret;
+  RETURN ret;
+END;
+$$ LANGUAGE 'plpgsql';
+
+
 
 -- Use regular user role
 SET ROLE test_regular_user;
@@ -24,3 +38,4 @@ SET ROLE test_regular_user;
 -- Exercise the exception safe and the proxied functions
 SELECT _cdb_geocode_street_point_exception_safe('One street, 1');
 SELECT the_geom FROM _cdb_isodistance_exception_safe('POINT(-3.70568 40.42028)'::geometry, 'walk', ARRAY[300]::integer[]);
+SELECT shape FROM _cdb_route_point_to_point_exception_safe('POINT(-3.70237112 40.41706163)'::geometry,'POINT(-3.69909883 40.41236875)'::geometry, 'car', ARRAY['mode_type=shortest']::text[]);


### PR DESCRIPTION
@jgoizueta @ethervoid  early and short review please.

Some remarks:
- I don't want to open a full debate as we already discussed this in a meeting. But... (keep reading)

- I'm pretty reluctant to adding these as "public functions", especially documentation and API wise (you know, upgrades, downgrades, keeping the same stable interface... in many schools of thought exceptions are part of the API). How about prepending an underscore and using them just from the analysis layer?

- I guess we can add specific treatment to some exceptions here, but IMO that misses the point of the whole thing. There are a few sources of exceptions:
  - programming errors (e.g: observatory raising an exception for a given input) => need to be fixed and  ideally should be detected before reaching prod
  - network issues: already working on retries and all that.
  - 3rd party issues: we can do little with those
  - **quota exhaustion**: this is the most specific case we want to deal with. Shall I deal with just this case??
  - any other I might be missing??

- Adding "unit tests" for this code is fairly easy. Testing E2E is a bit harder, even in local.

- The acceptance IMO is testing E2E with half the quota needed and checking than half the work can be carried out and kept, at least with the 3 types of function interfaces: `multi_row`, `multi_field` and the rest (the "normal" case).