### PR TITLE
Stop using git:// protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Steps to deploy a new Data Services API version :
 - install data services geocoder extension 
 
     ```
-    git clone git@github.com:CartoDB/data-services.git
+    git clone https://github.com/CartoDB/data-services.git
     cd data-services/geocoder/extension
     sudo make install
     ```
@@ -34,7 +34,7 @@ Steps to deploy a new Data Services API version :
 - install observatory extension 
 
     ```
-    git clone git@github.com:CartoDB/observatory-extension.git
+    git clone https://github.com/CartoDB/observatory-extension.git
     cd observatory
     sudo make install
     ```


### PR DESCRIPTION
## Context

`https://` protocol [is prefered](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended), plus using `git://` is messier in terms of permissions (using `git@` user, etc). 

Please consider changing your guide.