### PR TITLE
206 clean up non zero padded reads

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/metrics/user.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/user.py
@@ -118,12 +118,9 @@ class UserMetricsService:
         for date in self.__generate_date_range(date_from, date_to):
             redis_prefix = self.__parse_redis_prefix(key_prefix, entity_name,
                                                      service, metric, date)
-            score = self._redis_connection.zscore(redis_prefix, date.day)
-            aggregated_metric += int(score) if score else 0
             zero_padded_day = date.strftime(self.DAY_OF_MONTH_ZERO_PADDED)
-            if str(date.day) != zero_padded_day:
-                score = self._redis_connection.zscore(redis_prefix, zero_padded_day)
-                aggregated_metric += int(score) if score else 0
+            score = self._redis_connection.zscore(redis_prefix, zero_padded_day)
+            aggregated_metric += int(score) if score else 0
 
         return aggregated_metric
 

--- a/server/lib/python/cartodb_services/test/test_user_service.py
+++ b/server/lib/python/cartodb_services/test/test_user_service.py
@@ -90,19 +90,6 @@ class TestUserService(TestCase):
         self.redis_conn.zincrby('user:test_user:geocoder_here:success_responses:201506', '01', 400)
         assert us.used_quota(self.NOKIA_GEOCODER, date(2015, 6,1)) == 400
 
-    @freeze_time("2015-06-01")
-    def test_should_account_for_wrongly_stored_non_padded_keys(self):
-        us = self.__build_user_service('test_user')
-        self.redis_conn.zincrby('user:test_user:geocoder_here:success_responses:201506', '1', 400)
-        assert us.used_quota(self.NOKIA_GEOCODER, date(2015, 6,1)) == 400
-
-    @freeze_time("2015-06-01")
-    def test_should_sum_amounts_from_both_key_formats(self):
-        us = self.__build_user_service('test_user')
-        self.redis_conn.zincrby('user:test_user:geocoder_here:success_responses:201506',  '1', 400)
-        self.redis_conn.zincrby('user:test_user:geocoder_here:success_responses:201506', '01', 300)
-        assert us.used_quota(self.NOKIA_GEOCODER, date(2015, 6,1)) == 700
-
     @freeze_time("2015-06-15")
     def test_should_not_request_redis_twice_when_unneeded(self):
         class MockRedisWithCounter(MockRedis):


### PR DESCRIPTION
This fixes https://github.com/CartoDB/dataservices-api/issues/206

With this fix it looks better:
```sh
OK
1489148312.137894 [0 127.0.0.1:44012] "SELECT" "5"
1489148312.138239 [5 127.0.0.1:44012] "HGETALL" "rails:users:cdb"
1489148312.140310 [0 127.0.0.1:44013] "SELECT" "5"
1489148312.140607 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "18"
1489148312.141006 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "19"
1489148312.141448 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "20"
1489148312.141850 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "21"
1489148312.142284 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "22"
1489148312.142667 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "23"
1489148312.143028 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "24"
1489148312.143382 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "25"
1489148312.145284 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "26"
1489148312.145594 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "27"
1489148312.145850 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201702" "28"
1489148312.146207 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "01"
1489148312.146481 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "02"
1489148312.146746 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "03"
1489148312.147050 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "04"
1489148312.147292 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "05"
1489148312.147562 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "06"
1489148312.147889 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "07"
1489148312.148265 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "08"
1489148312.148678 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "09"
1489148312.148931 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:success_responses:201703" "10"
1489148312.149254 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "18"
1489148312.149507 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "19"
1489148312.149737 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "20"
1489148312.149947 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "21"
1489148312.150235 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "22"
1489148312.150446 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "23"
1489148312.150727 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "24"
1489148312.150968 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "25"
1489148312.151188 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "26"
1489148312.151416 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "27"
1489148312.151657 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201702" "28"
1489148312.151901 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "01"
1489148312.152122 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "02"
1489148312.152351 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "03"
1489148312.152586 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "04"
1489148312.152820 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "05"
1489148312.153113 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "06"
1489148312.153354 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "07"
1489148312.153622 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "08"
1489148312.153861 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "09"
1489148312.154230 [5 127.0.0.1:44013] "ZSCORE" "user:cdb:geocoder_mapzen:empty_responses:201703" "10"
1489148312.201499 [5 127.0.0.1:44013] "ZINCRBY" "user:cdb:geocoder_mapzen:success_responses:201703" "1" "10"
1489148312.202830 [5 127.0.0.1:44013] "ZINCRBY" "user:cdb:geocoder_mapzen:total_requests:201703" "1" "10"
```