### PR TITLE
Changes for local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Steps to deploy a new Data Services API version :
      psql -U postgres -d dataservices_db -c "BEGIN;GRANT SELECT ON ALL TABLES IN SCHEMA observatory TO dataservices_user; COMMIT" -e
      psql -U postgres -d dataservices_db -c "BEGIN;GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA observatory TO dataservices_user; COMMIT" -e
      ```
+     
+   - Configure geocoder API at `config/app_config.yml`:
+     ```
+     host: 'localhost'
+     port: '5432'
+     user: 'dataservices_user'
+     dbname: 'dataservices_db'
+     ```
 
 ### Server configuration
 


### PR DESCRIPTION
This adds needed changes at the configuration.

I  addition, I'm facing some issues while I try to load the geocoder dump.

If I follow the instructions, I run `geocoder_restore_dump` at `dataservices_db` and it fails:

```
psql:db_dumps/ne_admin0_v3.sql:293: ERROR:  Missing "public"._CDB_UserQuotaInBytes()
```

I thought that it might be caused by an inconsistency on the documentation, so I followed [geocoder installation instructions](https://github.com/CartoDB/data-services/tree/master/geocoder/extension) in order to run the dump into a CARTO user account instead of `dataservices_db`. Anyway, I got another error:

```
psql:db_dumps/ne_admin0_v3.sql:293: ERROR:  function _cdb_nonanalysistablesinschema(text) does not exist
LINE 6:     SELECT table_name FROM _CDB_NonAnalysisTablesInSchema(sc...
                                   ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

What am I doing wrong? cc @rafatower @ethervoid