### PR TITLE
Fix invalid geometries due to generalize option

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
@@ -28,7 +28,7 @@ def coordinates_to_polygon(coordinates):
     wkt_coordinates = ','.join(result_coordinates)
 
     try:
-        sql = "SELECT ST_MakePolygon(ST_GeomFromText('LINESTRING({0})', 4326)) as geom".format(wkt_coordinates)
+        sql = "SELECT ST_CollectionExtract(ST_MakeValid(ST_MakePolygon(ST_GeomFromText('LINESTRING({0})', 4326))),3) as geom".format(wkt_coordinates)
         geometry = plpy.execute(sql, 1)[0]['geom']
     except BaseException as e:
         plpy.warning("Can't generate POLYGON from coordinates: {0}".format(e))

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.15.3',
+    version='0.15.4',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
They add a note saying that use their simplification option could
lead to a self-intersection (which is the problem we have) and it's
creating invalid geometries

See it here https://mapzen.com/documentation/mobility/isochrone/api-reference/#other-request-parameters