### PR TITLE
Release python library version 0.15.4 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+August 30th, 2017
+=============
+* Version `0.15.4` of the python library
+    * Fixed invalid geometries for isochrones due to `generalize` option. See #397
+
 August 24th, 2017
 =============
 * Improved the documentation

--- a/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapzen/types.py
@@ -28,7 +28,7 @@ def coordinates_to_polygon(coordinates):
     wkt_coordinates = ','.join(result_coordinates)
 
     try:
-        sql = "SELECT ST_MakePolygon(ST_GeomFromText('LINESTRING({0})', 4326)) as geom".format(wkt_coordinates)
+        sql = "SELECT ST_CollectionExtract(ST_MakeValid(ST_MakePolygon(ST_GeomFromText('LINESTRING({0})', 4326))),3) as geom".format(wkt_coordinates)
         geometry = plpy.execute(sql, 1)[0]['geom']
     except BaseException as e:
         plpy.warning("Can't generate POLYGON from coordinates: {0}".format(e))

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.15.3',
+    version='0.15.4',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
* Fixed invalid geometries for isochrones due to `generalize` option. See #397