### PR TITLE
Keep metrics keys consistent

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/metrics/quota.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/quota.py
@@ -32,7 +32,7 @@ class QuotaService:
 
     def increment_failed_service_use(self, amount=1):
         self._user_service.increment_service_use(
-            self._user_service_config.service_type, "fail_responses",
+            self._user_service_config.service_type, "failed_responses",
             amount=amount)
         self._log_service_process("fail")
 

--- a/server/lib/python/cartodb_services/test/test_user_service.py
+++ b/server/lib/python/cartodb_services/test/test_user_service.py
@@ -52,7 +52,7 @@ class TestUserService(TestCase):
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 1
         us.increment_service_use(self.NOKIA_GEOCODER, 'empty_responses')
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
-        us.increment_service_use(self.NOKIA_GEOCODER, 'fail_responses')
+        us.increment_service_use(self.NOKIA_GEOCODER, 'failed_responses')
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
 
     def test_should_increment_org_used_quota(self):
@@ -61,7 +61,7 @@ class TestUserService(TestCase):
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 1
         us.increment_service_use(self.NOKIA_GEOCODER, 'empty_responses')
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
-        us.increment_service_use(self.NOKIA_GEOCODER, 'fail_responses')
+        us.increment_service_use(self.NOKIA_GEOCODER, 'failed_responses')
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
 
     def test_should_increment_user_used_quota_in_for_multiples_dates(self):
@@ -81,7 +81,7 @@ class TestUserService(TestCase):
         us.increment_service_use(self.NOKIA_GEOCODER, 'empty_responses',
                                  date=one_day_after)
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
-        us.increment_service_use(self.NOKIA_GEOCODER, 'fail_responses')
+        us.increment_service_use(self.NOKIA_GEOCODER, 'failed_responses')
         assert us.used_quota(self.NOKIA_GEOCODER, date.today()) == 2
 
     @freeze_time("2015-06-01")


### PR DESCRIPTION
See cartodb repo and our internal documentation:
https://github.com/CartoDB/cartodb/search?utf8=%E2%9C%93&q=failed_responses&type=