### PR TITLE
GoogleMapsClientFactory to persist clients #401

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
@@ -10,13 +10,14 @@ class GoogleMapsClientFactory():
 
     @classmethod
     def get(cls, client_id, client_secret):
-        client = cls.clients.get(client_id)
+        cache_key = "{}:{}".format(client_id, client_secret)
+        client = cls.clients.get(cache_key)
         if not client:
             cls.assert_valid_crendentials(client_secret)
             client = googlemaps.Client(
                 client_id=client_id,
                 client_secret=client_secret)
-            cls.clients[client_id] = client
+            cls.clients[cache_key] = client
         return client
 
     @classmethod

--- a/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
@@ -1,0 +1,17 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+
+import googlemaps
+
+class GoogleMapsClientFactory():
+    clients = {}
+
+    @classmethod
+    def get(cls, client_id, client_secret):
+        client = cls.clients.get(client_id)
+        if not client:
+            client = googlemaps.Client(
+                client_id=client_id,
+                client_secret=client_secret)
+            cls.clients[client_id] = client
+        return client

--- a/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
@@ -30,7 +30,8 @@ class GoogleMapsClientFactory():
             # Only fails if the string dont have a correct padding for b64
             # but this way we could provide a more clear error than
             # TypeError: Incorrect padding
-            base64.b64decode(client_secret)
+            b64_secret = client_secret.replace('-', '+').replace('_', '/')
+            base64.b64decode(b64_secret)
             return True
         except TypeError:
             return False

--- a/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/client_factory.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import googlemaps
+import base64
+from exceptions import InvalidGoogleCredentials
 
 class GoogleMapsClientFactory():
     clients = {}
@@ -10,8 +12,25 @@ class GoogleMapsClientFactory():
     def get(cls, client_id, client_secret):
         client = cls.clients.get(client_id)
         if not client:
+            cls.assert_valid_crendentials(client_secret)
             client = googlemaps.Client(
                 client_id=client_id,
                 client_secret=client_secret)
             cls.clients[client_id] = client
         return client
+
+    @classmethod
+    def assert_valid_crendentials(cls, client_secret):
+        if not cls.valid_credentials(client_secret):
+            raise InvalidGoogleCredentials
+
+    @staticmethod
+    def valid_credentials(client_secret):
+        try:
+            # Only fails if the string dont have a correct padding for b64
+            # but this way we could provide a more clear error than
+            # TypeError: Incorrect padding
+            base64.b64decode(client_secret)
+            return True
+        except TypeError:
+            return False

--- a/server/lib/python/cartodb_services/cartodb_services/google/geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/geocoder.py
@@ -1,10 +1,9 @@
 #!/usr/local/bin/python
 # -*- coding: utf-8 -*-
 
-import base64
 import googlemaps
 
-from exceptions import MalformedResult, InvalidGoogleCredentials
+from exceptions import MalformedResult
 from client_factory import GoogleMapsClientFactory
 
 

--- a/server/lib/python/cartodb_services/cartodb_services/google/geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/google/geocoder.py
@@ -5,18 +5,16 @@ import base64
 import googlemaps
 
 from exceptions import MalformedResult, InvalidGoogleCredentials
+from client_factory import GoogleMapsClientFactory
 
 
 class GoogleMapsGeocoder:
     """A Google Maps Geocoder wrapper for python"""
 
     def __init__(self, client_id, client_secret, logger):
-        if not self._valid_credentials(client_secret):
-            raise InvalidGoogleCredentials('Invalid google secret key')
         self.client_id = self._clean_client_id(client_id)
         self.client_secret = client_secret
-        self.geocoder = googlemaps.Client(
-            client_id=self.client_id, client_secret=self.client_secret)
+        self.geocoder = GoogleMapsClientFactory.get(self.client_id, self.client_secret)
         self._logger = logger
 
     def geocode(self, searchtext, city=None, state=None,
@@ -52,13 +50,3 @@ class GoogleMapsGeocoder:
     def _clean_client_id(self, client_id):
         # Consistency with how the client_id is saved in metadata
         return client_id.replace('client=', '')
-
-    def _valid_credentials(self, private_key):
-        try:
-            # Only fails if the string dont have a correct padding for b64
-            # but this way we could provide a more clear error than
-            # TypeError: Incorrect padding
-            base64.b64decode(private_key)
-            return True
-        except TypeError:
-            return False

--- a/server/lib/python/cartodb_services/test/test_google_client_factory.py
+++ b/server/lib/python/cartodb_services/test/test_google_client_factory.py
@@ -5,6 +5,7 @@ import unittest
 import base64
 
 from cartodb_services.google.client_factory import GoogleMapsClientFactory
+from cartodb_services.google.exceptions import InvalidGoogleCredentials
 
 class GoogleMapsClientFactoryTestCase(unittest.TestCase):
 
@@ -45,3 +46,13 @@ class GoogleMapsClientFactoryTestCase(unittest.TestCase):
         client1 = GoogleMapsClientFactory.get(id1, key)
         client2 = GoogleMapsClientFactory.get(id2, key)
         self.assertNotEqual(client1, client2)
+
+    def test_invalid_credentials(self):
+        with self.assertRaises(InvalidGoogleCredentials):
+            GoogleMapsClientFactory.get('dummy_client_id', 'lalala')
+
+    def test_credentials_with_dashes_can_be_valid(self):
+        GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola-k-ase---')
+
+    def test_credentials_with_underscores_can_be_valid(self):
+        GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola_k_ase___')

--- a/server/lib/python/cartodb_services/test/test_google_client_factory.py
+++ b/server/lib/python/cartodb_services/test/test_google_client_factory.py
@@ -1,0 +1,47 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+import base64
+
+from cartodb_services.google.client_factory import GoogleMapsClientFactory
+
+class GoogleMapsClientFactoryTestCase(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        # reset client cache
+        GoogleMapsClientFactory.clients = {}
+
+    def test_consecutive_calls_with_same_params_return_same_client(self):
+        id = 'any_id'
+        key = base64.b64encode('any_key')
+        client1 = GoogleMapsClientFactory.get(id, key)
+        client2 = GoogleMapsClientFactory.get(id, key)
+        self.assertEqual(client1, client2)
+
+    def test_consecutive_calls_with_different_key_return_different_clients(self):
+        """
+        This requirement is important for security reasons as well as not to
+        cache a wrong key accidentally.
+        """
+        id = 'any_id'
+        key1 = base64.b64encode('any_key')
+        key2 = base64.b64encode('another_key')
+        client1 = GoogleMapsClientFactory.get(id, key1)
+        client2 = GoogleMapsClientFactory.get(id, key2)
+        self.assertNotEqual(client1, client2)
+
+    def test_consecutive_calls_with_different_ids_return_different_clients(self):
+        """
+        This requirement is important for security reasons as well as not to
+        cache a wrong key accidentally.
+        """
+        id1 = 'any_id'
+        id2 = 'another_id'
+        key = base64.b64encode('any_key')
+        client1 = GoogleMapsClientFactory.get(id1, key)
+        client2 = GoogleMapsClientFactory.get(id2, key)
+        self.assertNotEqual(client1, client2)

--- a/server/lib/python/cartodb_services/test/test_google_client_factory.py
+++ b/server/lib/python/cartodb_services/test/test_google_client_factory.py
@@ -1,6 +1,7 @@
 #!/usr/local/bin/python
 # -*- coding: utf-8 -*-
 
+import googlemaps
 import unittest
 import base64
 
@@ -52,7 +53,9 @@ class GoogleMapsClientFactoryTestCase(unittest.TestCase):
             GoogleMapsClientFactory.get('dummy_client_id', 'lalala')
 
     def test_credentials_with_dashes_can_be_valid(self):
-        GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola-k-ase---')
+        client = GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola-k-ase---')
+        self.assertIsInstance(client, googlemaps.Client)
 
     def test_credentials_with_underscores_can_be_valid(self):
-        GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola_k_ase___')
+        client = GoogleMapsClientFactory.get('yet_another_dummy_client_id', 'Ola_k_ase___')
+        self.assertIsInstance(client, googlemaps.Client)

--- a/server/lib/python/cartodb_services/test/test_googlegeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_googlegeocoder.py
@@ -121,6 +121,6 @@ class GoogleGeocoderTestCase(unittest.TestCase):
 
     def test_invalid_credentials(self, req_mock):
         with self.assertRaises(InvalidGoogleCredentials):
-            GoogleMapsGeocoder('dummy_client_id',
+            GoogleMapsGeocoder('another_dummy_client_id',
                                'lalala',
                                None)

--- a/server/lib/python/cartodb_services/test/test_googlegeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_googlegeocoder.py
@@ -124,3 +124,13 @@ class GoogleGeocoderTestCase(unittest.TestCase):
             GoogleMapsGeocoder('another_dummy_client_id',
                                'lalala',
                                None)
+
+    def test_credentials_with_dashes_can_be_valid(self, req_mock):
+        GoogleMapsGeocoder('yet_another_dummy_client_id',
+                           'Ola-k-ase---',
+                           None)
+
+    def test_credentials_with_underscores_can_be_valid(self, req_mock):
+        GoogleMapsGeocoder('yet_another_dummy_client_id',
+                           'Ola_k_ase___',
+                           None)

--- a/server/lib/python/cartodb_services/test/test_googlegeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_googlegeocoder.py
@@ -6,7 +6,7 @@ import requests_mock
 from mock import Mock
 
 from cartodb_services.google import GoogleMapsGeocoder
-from cartodb_services.google.exceptions import MalformedResult, InvalidGoogleCredentials
+from cartodb_services.google.exceptions import MalformedResult
 
 requests_mock.Mocker.TEST_PREFIX = 'test_'
 
@@ -118,19 +118,3 @@ class GoogleGeocoderTestCase(unittest.TestCase):
                 searchtext='Calle Eloy Gonzalo 27',
                 city='Madrid',
                 country='España')
-
-    def test_invalid_credentials(self, req_mock):
-        with self.assertRaises(InvalidGoogleCredentials):
-            GoogleMapsGeocoder('dummy_client_id',
-                               'lalala',
-                               None)
-
-    def test_credentials_with_dashes_can_be_valid(self, req_mock):
-        GoogleMapsGeocoder('yet_another_dummy_client_id',
-                           'Ola-k-ase---',
-                           None)
-
-    def test_credentials_with_underscores_can_be_valid(self, req_mock):
-        GoogleMapsGeocoder('yet_another_dummy_client_id',
-                           'Ola_k_ase___',
-                           None)

--- a/server/lib/python/cartodb_services/test/test_googlegeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_googlegeocoder.py
@@ -121,7 +121,7 @@ class GoogleGeocoderTestCase(unittest.TestCase):
 
     def test_invalid_credentials(self, req_mock):
         with self.assertRaises(InvalidGoogleCredentials):
-            GoogleMapsGeocoder('another_dummy_client_id',
+            GoogleMapsGeocoder('dummy_client_id',
                                'lalala',
                                None)
 


### PR DESCRIPTION
This fixes #401 

This adds an in-memory cache for clients. Internally they use `Session` objects that persist connections. See https://github.com/googlemaps/google-maps-services-python/pull/164 https://github.com/googlemaps/google-maps-services-python/issues/163 and http://docs.python-requests.org/en/master/user/advanced/#session-objects

As a bonus, it also fixes client keys validity check #382 