### PR TITLE
[DNM] Fix bad renaming of function parameter

### DIFF
--- a/client/cdb_dataservices_client--0.21.0--0.22.0.sql
+++ b/client/cdb_dataservices_client--0.21.0--0.22.0.sql
@@ -3800,7 +3800,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER STABLE PARALLEL UNSAFE;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/cdb_dataservices_client--0.22.0--0.21.0.sql
+++ b/client/cdb_dataservices_client--0.22.0--0.21.0.sql
@@ -3798,7 +3798,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/cdb_dataservices_client--0.22.0.sql
+++ b/client/cdb_dataservices_client--0.22.0.sql
@@ -3840,7 +3840,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER STABLE PARALLEL UNSAFE;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.16.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.16.0.sql
@@ -3594,7 +3594,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.17.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.17.0.sql
@@ -3594,7 +3594,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.18.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.18.0.sql
@@ -3716,7 +3716,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.19.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.19.0.sql
@@ -3777,7 +3777,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.20.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.20.0.sql
@@ -3838,7 +3838,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   

--- a/client/old_versions/cdb_dataservices_client--0.21.0.sql
+++ b/client/old_versions/cdb_dataservices_client--0.21.0.sql
@@ -3838,7 +3838,7 @@ BEGIN
   END;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)
 RETURNS Geometry AS $$
   CONNECT cdb_dataservices_client._server_conn_str();
   


### PR DESCRIPTION
This fixes the following error when trying to upgrade:

```
cannot change name of input parameter "organization_name"
```

The problem was introduced ages ago. I fixed it by running a script:

```bash
BAD_REGEXP='CREATE OR REPLACE FUNCTION cdb_dataservices_client\._cdb_geocode_admin0_polygon (username text, orgname text, country_name text)'
REPLACEMENT='CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin0_polygon (username text, organization_name text, country_name text)'
git grep -l "$BAD_REGEXP" | xargs sed -i "s/$BAD_REGEXP/$REPLACEMENT/g"
```