### PR TITLE
Fixed encoding problem with Mapbox geocoding

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/mapbox/geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapbox/geocoder.py
@@ -69,7 +69,7 @@ class MapboxGeocoder(Traceable):
         country = [country] if country else None
 
         try:
-            response = self._geocoder.forward(address=', '.join(address),
+            response = self._geocoder.forward(address=', '.join(address).decode('utf-8'),
                                               country=country,
                                               limit=1)
 

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.16.0',
+    version='0.16.1',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
Fixed encoding problem with Mapbox geocoding (using the Mapbox Python library)

**Note for the acceptance:** this can be tested with a street like `Calle Fray Luis de León 1, Valladolid`