### PR TITLE
457 fix mapbox python tests

### DIFF
--- a/server/lib/python/cartodb_services/test/credentials.py
+++ b/server/lib/python/cartodb_services/test/credentials.py
@@ -1,0 +1,6 @@
+import os
+
+def api_key():
+    """Returns Mapbox API key. Requires setting MAPBOX_API_KEY environment variable."""
+    return os.environ['MAPBOX_API_KEY']
+

--- a/server/lib/python/cartodb_services/test/credentials.py
+++ b/server/lib/python/cartodb_services/test/credentials.py
@@ -1,6 +1,6 @@
 import os
 
-def api_key():
+def mapbox_api_key():
     """Returns Mapbox API key. Requires setting MAPBOX_API_KEY environment variable."""
     return os.environ['MAPBOX_API_KEY']
 

--- a/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
@@ -12,7 +12,7 @@ WELL_KNOWN_LATITUDE = 41.668654
 
 class MapboxGeocoderTestCase(unittest.TestCase):
     def setUp(self):
-        self.geocoder = MapboxGeocoder(token=credentials.api_key(), logger=Mock())
+        self.geocoder = MapboxGeocoder(token=credentials.mapbox_api_key(), logger=Mock())
 
     def test_invalid_token(self):
         invalid_geocoder = MapboxGeocoder(token=INVALID_TOKEN, logger=Mock())

--- a/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
@@ -2,8 +2,8 @@ import unittest
 from mock import Mock
 from cartodb_services.mapbox import MapboxGeocoder
 from cartodb_services.tools.exceptions import ServiceException
+import credentials
 
-VALID_TOKEN = 'pk.eyJ1IjoiYWNhcmxvbiIsImEiOiJjamJuZjQ1Zjc0Ymt4Mnh0YmFrMmhtYnY4In0.gt9cw0VeKc3rM2mV5pcEmg'
 INVALID_TOKEN = 'invalid_token'
 VALID_ADDRESS = 'Calle Siempreviva 3, Valladolid'
 WELL_KNOWN_LONGITUDE = -4.730947
@@ -12,7 +12,7 @@ WELL_KNOWN_LATITUDE = 41.668654
 
 class MapboxGeocoderTestCase(unittest.TestCase):
     def setUp(self):
-        self.geocoder = MapboxGeocoder(token=VALID_TOKEN, logger=Mock())
+        self.geocoder = MapboxGeocoder(token=credentials.api_key(), logger=Mock())
 
     def test_invalid_token(self):
         invalid_geocoder = MapboxGeocoder(token=INVALID_TOKEN, logger=Mock())

--- a/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxgeocoder.py
@@ -2,7 +2,7 @@ import unittest
 from mock import Mock
 from cartodb_services.mapbox import MapboxGeocoder
 from cartodb_services.tools.exceptions import ServiceException
-import credentials
+from credentials import mapbox_api_key
 
 INVALID_TOKEN = 'invalid_token'
 VALID_ADDRESS = 'Calle Siempreviva 3, Valladolid'
@@ -12,7 +12,7 @@ WELL_KNOWN_LATITUDE = 41.668654
 
 class MapboxGeocoderTestCase(unittest.TestCase):
     def setUp(self):
-        self.geocoder = MapboxGeocoder(token=credentials.mapbox_api_key(), logger=Mock())
+        self.geocoder = MapboxGeocoder(token=mapbox_api_key(), logger=Mock())
 
     def test_invalid_token(self):
         invalid_geocoder = MapboxGeocoder(token=INVALID_TOKEN, logger=Mock())

--- a/server/lib/python/cartodb_services/test/test_mapboxisoline.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxisoline.py
@@ -7,15 +7,15 @@ from cartodb_services.mapbox.routing import MapboxRouting
 from cartodb_services.tools import Coordinate
 from cartodb_services.tools.coordinates import (validate_coordinates,
                                                 marshall_coordinates)
+import credentials
 
-VALID_TOKEN = 'pk.eyJ1IjoiYWNhcmxvbiIsImEiOiJjamJuZjQ1Zjc0Ymt4Mnh0YmFrMmhtYnY4In0.gt9cw0VeKc3rM2mV5pcEmg'
 VALID_ORIGIN = Coordinate(-73.989, 40.733)
 
 
 class MapboxIsolinesTestCase(unittest.TestCase):
 
     def setUp(self):
-        matrix_client = MapboxMatrixClient(token=VALID_TOKEN, logger=Mock())
+        matrix_client = MapboxMatrixClient(token=credentials.api_key(), logger=Mock())
         self.mapbox_isolines = MapboxIsolines(matrix_client, logger=Mock())
 
     def test_calculate_isochrone(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxisoline.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxisoline.py
@@ -15,7 +15,7 @@ VALID_ORIGIN = Coordinate(-73.989, 40.733)
 class MapboxIsolinesTestCase(unittest.TestCase):
 
     def setUp(self):
-        matrix_client = MapboxMatrixClient(token=credentials.api_key(), logger=Mock())
+        matrix_client = MapboxMatrixClient(token=credentials.mapbox_api_key(), logger=Mock())
         self.mapbox_isolines = MapboxIsolines(matrix_client, logger=Mock())
 
     def test_calculate_isochrone(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxisoline.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxisoline.py
@@ -7,7 +7,7 @@ from cartodb_services.mapbox.routing import MapboxRouting
 from cartodb_services.tools import Coordinate
 from cartodb_services.tools.coordinates import (validate_coordinates,
                                                 marshall_coordinates)
-import credentials
+from credentials import mapbox_api_key
 
 VALID_ORIGIN = Coordinate(-73.989, 40.733)
 
@@ -15,7 +15,7 @@ VALID_ORIGIN = Coordinate(-73.989, 40.733)
 class MapboxIsolinesTestCase(unittest.TestCase):
 
     def setUp(self):
-        matrix_client = MapboxMatrixClient(token=credentials.mapbox_api_key(), logger=Mock())
+        matrix_client = MapboxMatrixClient(token=mapbox_api_key(), logger=Mock())
         self.mapbox_isolines = MapboxIsolines(matrix_client, logger=Mock())
 
     def test_calculate_isochrone(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
@@ -4,8 +4,8 @@ from cartodb_services.mapbox import MapboxMatrixClient
 from cartodb_services.mapbox.matrix_client import DEFAULT_PROFILE
 from cartodb_services.tools.exceptions import ServiceException
 from cartodb_services.tools import Coordinate
+import credentials
 
-VALID_TOKEN = 'pk.eyJ1IjoiYWNhcmxvbiIsImEiOiJjamJuZjQ1Zjc0Ymt4Mnh0YmFrMmhtYnY4In0.gt9cw0VeKc3rM2mV5pcEmg'
 INVALID_TOKEN = 'invalid_token'
 VALID_ORIGIN = Coordinate(-73.989, 40.733)
 VALID_TARGET = Coordinate(-74, 40.733)
@@ -22,7 +22,7 @@ INVALID_PROFILE = 'invalid_profile'
 
 class MapboxMatrixTestCase(unittest.TestCase):
     def setUp(self):
-        self.matrix_client = MapboxMatrixClient(token=VALID_TOKEN,
+        self.matrix_client = MapboxMatrixClient(token=credentials.api_key(),
                                                 logger=Mock())
 
     def test_invalid_profile(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
@@ -22,7 +22,7 @@ INVALID_PROFILE = 'invalid_profile'
 
 class MapboxMatrixTestCase(unittest.TestCase):
     def setUp(self):
-        self.matrix_client = MapboxMatrixClient(token=credentials.api_key(),
+        self.matrix_client = MapboxMatrixClient(token=credentials.mapbox_api_key(),
                                                 logger=Mock())
 
     def test_invalid_profile(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxmatrix.py
@@ -4,7 +4,7 @@ from cartodb_services.mapbox import MapboxMatrixClient
 from cartodb_services.mapbox.matrix_client import DEFAULT_PROFILE
 from cartodb_services.tools.exceptions import ServiceException
 from cartodb_services.tools import Coordinate
-import credentials
+from credentials import mapbox_api_key
 
 INVALID_TOKEN = 'invalid_token'
 VALID_ORIGIN = Coordinate(-73.989, 40.733)
@@ -22,7 +22,7 @@ INVALID_PROFILE = 'invalid_profile'
 
 class MapboxMatrixTestCase(unittest.TestCase):
     def setUp(self):
-        self.matrix_client = MapboxMatrixClient(token=credentials.mapbox_api_key(),
+        self.matrix_client = MapboxMatrixClient(token=mapbox_api_key(),
                                                 logger=Mock())
 
     def test_invalid_profile(self):

--- a/server/lib/python/cartodb_services/test/test_mapboxrouting.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxrouting.py
@@ -31,7 +31,7 @@ WELL_KNOWN_LENGTH = 1317.9
 
 class MapboxRoutingTestCase(unittest.TestCase):
     def setUp(self):
-        self.routing = MapboxRouting(token=credentials.api_key(), logger=Mock())
+        self.routing = MapboxRouting(token=credentials.mapbox_api_key(), logger=Mock())
 
     def test_invalid_profile(self):
         with self.assertRaises(ValueError):

--- a/server/lib/python/cartodb_services/test/test_mapboxrouting.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxrouting.py
@@ -4,7 +4,7 @@ from cartodb_services.mapbox import MapboxRouting
 from cartodb_services.mapbox.routing import DEFAULT_PROFILE
 from cartodb_services.tools.exceptions import ServiceException
 from cartodb_services.tools import Coordinate
-import credentials
+from credentials import mapbox_api_key
 
 INVALID_TOKEN = 'invalid_token'
 VALID_WAYPOINTS = [Coordinate(-73.989, 40.733), Coordinate(-74, 40.733)]
@@ -31,7 +31,7 @@ WELL_KNOWN_LENGTH = 1317.9
 
 class MapboxRoutingTestCase(unittest.TestCase):
     def setUp(self):
-        self.routing = MapboxRouting(token=credentials.mapbox_api_key(), logger=Mock())
+        self.routing = MapboxRouting(token=mapbox_api_key(), logger=Mock())
 
     def test_invalid_profile(self):
         with self.assertRaises(ValueError):

--- a/server/lib/python/cartodb_services/test/test_mapboxrouting.py
+++ b/server/lib/python/cartodb_services/test/test_mapboxrouting.py
@@ -4,8 +4,8 @@ from cartodb_services.mapbox import MapboxRouting
 from cartodb_services.mapbox.routing import DEFAULT_PROFILE
 from cartodb_services.tools.exceptions import ServiceException
 from cartodb_services.tools import Coordinate
+import credentials
 
-VALID_TOKEN = 'pk.eyJ1IjoiYWNhcmxvbiIsImEiOiJjamJuZjQ1Zjc0Ymt4Mnh0YmFrMmhtYnY4In0.gt9cw0VeKc3rM2mV5pcEmg'
 INVALID_TOKEN = 'invalid_token'
 VALID_WAYPOINTS = [Coordinate(-73.989, 40.733), Coordinate(-74, 40.733)]
 NUM_WAYPOINTS_MAX = 25
@@ -31,7 +31,7 @@ WELL_KNOWN_LENGTH = 1317.9
 
 class MapboxRoutingTestCase(unittest.TestCase):
     def setUp(self):
-        self.routing = MapboxRouting(token=VALID_TOKEN, logger=Mock())
+        self.routing = MapboxRouting(token=credentials.api_key(), logger=Mock())
 
     def test_invalid_profile(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This closes #457. For tests to pass, a `MAPBOX_API_KEY` environment variable must be provided.