### PR TITLE
Fix Mapbox isolines near the shoreline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+February 22th, 2018
+==================
+* Version `0.17.2` of the python library
+    * Fix bug with Mapbox isolines not stopping at the seacoast
+
 February 27th, 2018
 ==================
 * Version `0.17.1` of the python library

--- a/server/lib/python/cartodb_services/cartodb_services/mapbox/isolines.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapbox/isolines.py
@@ -162,7 +162,7 @@ class MapboxIsolines():
         # delete points that got None
         location_estimates_filtered = []
         for i, c in enumerate(costs):
-            if c != isorange:
+            if c < isorange * (1 + tolerance):
                 location_estimates_filtered.append(destinations[i])
 
         return location_estimates_filtered

--- a/server/lib/python/cartodb_services/cartodb_services/mapbox/isolines.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapbox/isolines.py
@@ -162,7 +162,7 @@ class MapboxIsolines():
         # delete points that got None
         location_estimates_filtered = []
         for i, c in enumerate(costs):
-            if c < isorange * (1 + tolerance):
+            if c != isorange and c < isorange * (1 + tolerance):
                 location_estimates_filtered.append(destinations[i])
 
         return location_estimates_filtered

--- a/server/lib/python/cartodb_services/cartodb_services/mapbox/matrix_client.py
+++ b/server/lib/python/cartodb_services/cartodb_services/mapbox/matrix_client.py
@@ -30,6 +30,8 @@ VALID_PROFILES = [PROFILE_DRIVING_TRAFFIC,
                   PROFILE_WALKING]
 
 ENTRY_DURATIONS = 'durations'
+ENTRY_DESTINATIONS = 'destinations'
+ENTRY_LOCATION = 'location'
 
 
 def validate_profile(profile):

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.17.1',
+    version='0.17.2',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
Using the returned destination coordinates from the Mapbox matrix client as the isolines coordinates instead of the calculated ones.

The complete solution would be actually clipping the returned polygon using the shoreline, but this may be a good enough approximation.

Old behavior:
![screenshot from 2018-02-26 12-59-39](https://user-images.githubusercontent.com/6155203/36669393-1826d786-1af5-11e8-98a4-479436996b72.png)

New behavior:
![screenshot from 2018-02-26 13-00-39](https://user-images.githubusercontent.com/6155203/36669397-1cfed2a4-1af5-11e8-9f66-578b8d2d2c09.png)

**Note:** as a side effect, as we are using the Mapbox returned coordinates instead of the calculated ones, we are slightly improving the rest of the isoline (notice the change in the borders).

Fixes https://github.com/CartoDB/support/issues/1333