### PR TITLE
Fix mapzen routing bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+
+February 27th, 2018
+==================
+* Version `0.17.1` of the python library
+    * Fix bug when the mapzen credentials are not in the db config and we keep getting them
+
 February 22th, 2018
 ==================
 * Version `0.17.0` of the python library

--- a/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
+++ b/server/lib/python/cartodb_services/cartodb_services/metrics/config.py
@@ -147,10 +147,12 @@ class RoutingConfig(ServiceConfig):
         self._routing_provider = self._redis_config[self.ROUTING_PROVIDER_KEY]
         if not self._routing_provider:
             self._routing_provider = self.DEFAULT_PROVIDER
-        self._mapzen_api_key = self._db_config.mapzen_routing_api_key
-        self._mapzen_service_params = self._db_config.mapzen_routing_service_params
-        self._mapbox_api_keys = self._db_config.mapbox_routing_api_keys
-        self._mapbox_service_params = self._db_config.mapbox_routing_service_params
+        if self._routing_provider == self.MAPZEN_PROVIDER:
+            self._mapzen_api_key = self._db_config.mapzen_routing_api_key
+            self._mapzen_service_params = self._db_config.mapzen_routing_service_params
+        elif self._routing_provider == self.MAPBOX_PROVIDER:
+            self._mapbox_api_keys = self._db_config.mapbox_routing_api_keys
+            self._mapbox_service_params = self._db_config.mapbox_routing_service_params
         self._set_monthly_quota()
         self._set_soft_limit()
         self._period_end_date = date_parse(self._redis_config[self.PERIOD_END_DATE])

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.17.0',
+    version='0.17.1',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
Related #467 

We keep trying to gather Mapzen credentials from the database but now is possible to not have them so that leads to an exception 