### PR TITLE
Fixed tests

### DIFF
--- a/test/integration/test_admin0_functions.py
+++ b/test/integration/test_admin0_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,7 +12,6 @@ class TestAdmin0Functions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_admin0_is_ok(self):
@@ -29,4 +28,4 @@ class TestAdmin0Functions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_admin0_polygon(text) does not exist"])

--- a/test/integration/test_admin0_functions.py
+++ b/test/integration/test_admin0_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -28,4 +28,4 @@ class TestAdmin0Functions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_admin0_polygon(text) does not exist"])
+            assert_in(e.message[0], ["Geocoding permission denied", "function cdb_geocode_admin0_polygon(text) does not exist"])

--- a/test/integration/test_admin1_functions.py
+++ b/test/integration/test_admin1_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,30 +12,29 @@ class TestAdmin1Functions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_admin1_without_country_is_ok(self):
         query = "SELECT cdb_geocode_admin1_polygon(province) as geometry " \
             "FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_admin1_with_country_is_ok(self):
         query = "SELECT cdb_geocode_admin1_polygon(province,country)" \
             "as geometry FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_admin1_without_api_key_raise_error(self):
         query = "SELECT cdb_geocode_admin1_polygon(province) as geometry " \
             "FROM {0} LIMIT 1".format(
-            self.env_variables['table_name'])
+                self.env_variables['table_name'])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_admin1_polygon(text) does not exist"])

--- a/test/integration/test_admin1_functions.py
+++ b/test/integration/test_admin1_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -37,4 +37,4 @@ class TestAdmin1Functions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_admin1_polygon(text) does not exist"])
+            assert_in(e.message[0], ["Geocoding permission denied", "function cdb_geocode_admin1_polygon(text) does not exist"])

--- a/test/integration/test_data_observatory_functions.py
+++ b/test/integration/test_data_observatory_functions.py
@@ -24,7 +24,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getdemographicsnapshot(geometry) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getdemographicsnapshot(geometry) does not exist"])
 
     def test_if_get_segment_snapshot_is_ok(self):
         query = "SELECT OBS_GetSegmentSnapshot(CDB_LatLng(40.704512, -73.936669)) as snapshot;&api_key={0}".format(self.env_variables['api_key'])
@@ -36,7 +36,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getsegmentsnapshot(geometry) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getsegmentsnapshot(geometry) does not exist"])
 
     def test_if_get_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetMeasure(CDB_LatLng(40.704512, -73.936669), 'us.census.acs.B01003001') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -53,7 +53,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeasure(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_measure_by_id_ok(self):
         query = "SELECT OBS_GetMeasureById('36047048500', 'us.census.acs.B01003001', 'us.census.tiger.census_tract', '2010 - 2014') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -65,7 +65,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeasurebyid(unknown, unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getmeasurebyid(unknown, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_category_is_ok(self):
         query = "SELECT OBS_GetCategory(CDB_LatLng(40.704512, -73.936669), 'us.census.spielman_singleton_segments.X10', 'us.census.tiger.census_tract', '2010 - 2014') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -77,7 +77,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getcategory(geometry, unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getcategory(geometry, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_us_census_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetUSCensusMeasure(CDB_LatLng(40.704512, -73.936669), 'male population') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -94,7 +94,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getuscensusmeasure(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getuscensusmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_us_census_category_is_ok(self):
         query = "SELECT OBS_GetUSCensusCategory('0103000020E61000000100000021000000BB366F6D917B52C0E7BB6EA82B5A444067224C85937B52C0810205E70E5A4440596D6342997B52C09BED2952F35944400A96386CA27B52C07B6D31F9D95944402B81A0A8AE7B52C0D16B73D5C3594440C34C397FBD7B52C0D8B5B7C0B1594440CFD90A5ECE7B52C0BE8DD86CA45944405C7E229FE07B52C0A904EE5C9C59444017C1F28EF37B52C05E2745E099594440AE8A3873067C52C0FD62540F9D5944402F272292187C52C05502CBCAA5594440C3F17139297C52C0B3FBC4BCB3594440DDAE56C5377C52C00C46175CC6594440E96AB6A6437C52C0355C94F1DC5944402313AE684C7C52C05340159FF6594440B3B90FB5517C52C031F30168125A44407F43B357537C52C0DF95053B2F5A444059C17840517C52C0D9E08EFC4B5A44406580E8834B7C52C046B5B591675A444035736A5A427C52C0AF9A1AEB805A44402E721C1E367C52C0D226550F975A4440506D5C47277C52C0A2968A24A95A4440507C2868167C52C0D51FCE78B65A4440C4438226047C52C02369F888BE5A4440C9F10C36F17B52C027B1B205C15A4440AABE2451DE7B52C0F5E383D6BD5A44402A18B431CC7B52C01785C11AB55A444018320D8ABB7B52C070265B28A75A4440E28A0EFEAC7B52C09E518C88945A44401D08D61CA17B52C09E8195F27D5A4440D7C3405B987B52C0643CB044645A444047B16D0F937B52C04EC9837B485A4440BB366F6D917B52C0E7BB6EA82B5A4440'::geometry, 'Spielman-Singleton Segments: 10 Clusters') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -106,7 +106,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getuscensuscategory(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getuscensuscategory(geometry, unknown) does not exist"])
 
     def test_if_get_population_is_ok(self):
         query = "SELECT OBS_GetPopulation(CDB_LatLng(40.704512, -73.936669)) as population;&api_key={0}".format(self.env_variables['api_key'])
@@ -118,7 +118,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpopulation(geometry) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getpopulation(geometry) does not exist"])
 
     def test_if_obs_search_is_ok(self):
         sql = "SELECT id FROM OBS_Search('total_pop') WHERE id LIKE 'es.ine%' LIMIT 1;"
@@ -132,7 +132,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_search(unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_search(unknown) does not exist"])
 
     def test_if_obs_get_available_boundaries_is_ok(self):
         query = "SELECT boundary_id FROM OBS_GetAvailableBoundaries(CDB_LatLng(40.704512, -73.936669)) LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -144,7 +144,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailableboundaries(geometry) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getavailableboundaries(geometry) does not exist"])
 
     def test_if_obs_get_boundary_is_ok(self):
         query = "SELECT OBS_GetBoundary(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -156,7 +156,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundary(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getboundary(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundary_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryId(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract', '2015') as boundary_id;&api_key={0}".format(self.env_variables['api_key'])
@@ -168,7 +168,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundaryid(geometry, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getboundaryid(geometry, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundary_by_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryById('36047', 'us.census.tiger.county', '2014') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -180,7 +180,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundarybyid(unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getboundarybyid(unknown, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -192,7 +192,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundariesbygeometry(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getboundariesbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -204,7 +204,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundariesbypointandradius(geometry, integer, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getboundariesbypointandradius(geometry, integer, unknown) does not exist"])
 
     def test_if_obs_get_points_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -216,7 +216,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpointsbygeometry(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getpointsbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_points_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract', '2014') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -228,7 +228,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpointsbypointandradius(geometry, integer, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getpointsbypointandradius(geometry, integer, unknown, unknown) does not exist"])
 
     def test_if_obs_get_legacy_builder_metadata_is_ok(self):
         query = "SELECT name FROM OBS_LegacyBuilderMetadata() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -240,7 +240,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_legacybuildermetadata() does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_legacybuildermetadata() does not exist"])
 
     def test_if_obs_get_available_numerators_is_ok(self):
         query = "SELECT numer_id FROM OBS_GetAvailableNumerators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -252,7 +252,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailablenumerators() does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getavailablenumerators() does not exist"])
 
     def test_if_obs_get_available_denominators_is_ok(self):
         query = "SELECT denom_id FROM OBS_GetAvailableDenominators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -264,7 +264,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailabledenominators() does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getavailabledenominators() does not exist"])
 
     def test_if_obs_get_available_geometries_is_ok(self):
         query = "SELECT geom_id FROM OBS_GetAvailableGeometries() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -276,7 +276,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailablegeometries() does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getavailablegeometries() does not exist"])
 
     def test_if_obs_get_available_timespans_is_ok(self):
         query = "SELECT timespan_id FROM OBS_GetAvailableTimespans() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -288,7 +288,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailabletimespans() does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getavailabletimespans() does not exist"])
 
     def test_if_obs_get_meta_is_ok(self):
         params = '\'[{\"numer_id\": \"us.census.acs.B01003001\"}]\''
@@ -302,7 +302,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
 
     def test_if_obs_get_data_is_ok(self):
         params_1 = '\'[{\"numer_id\": \"us.census.acs.B01003001\", \"geom_id\": \"us.census.tiger.county\"}]\''
@@ -322,8 +322,8 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_1)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_2)
         except Exception as e:
-            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Data Observatory permission denied", "function obs_getmeta(geometry, unknown) does not exist"])

--- a/test/integration/test_data_observatory_functions.py
+++ b/test/integration/test_data_observatory_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -24,7 +24,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getdemographicsnapshot(geometry) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getdemographicsnapshot(geometry) does not exist"])
 
     def test_if_get_segment_snapshot_is_ok(self):
         query = "SELECT OBS_GetSegmentSnapshot(CDB_LatLng(40.704512, -73.936669)) as snapshot;&api_key={0}".format(self.env_variables['api_key'])
@@ -36,7 +36,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getsegmentsnapshot(geometry) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getsegmentsnapshot(geometry) does not exist"])
 
     def test_if_get_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetMeasure(CDB_LatLng(40.704512, -73.936669), 'us.census.acs.B01003001') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -53,7 +53,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeasure(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_measure_by_id_ok(self):
         query = "SELECT OBS_GetMeasureById('36047048500', 'us.census.acs.B01003001', 'us.census.tiger.census_tract', '2010 - 2014') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -65,7 +65,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeasurebyid(unknown, unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeasurebyid(unknown, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_category_is_ok(self):
         query = "SELECT OBS_GetCategory(CDB_LatLng(40.704512, -73.936669), 'us.census.spielman_singleton_segments.X10', 'us.census.tiger.census_tract', '2010 - 2014') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -77,7 +77,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getcategory(geometry, unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getcategory(geometry, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_us_census_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetUSCensusMeasure(CDB_LatLng(40.704512, -73.936669), 'male population') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -94,7 +94,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getuscensusmeasure(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getuscensusmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_us_census_category_is_ok(self):
         query = "SELECT OBS_GetUSCensusCategory('0103000020E61000000100000021000000BB366F6D917B52C0E7BB6EA82B5A444067224C85937B52C0810205E70E5A4440596D6342997B52C09BED2952F35944400A96386CA27B52C07B6D31F9D95944402B81A0A8AE7B52C0D16B73D5C3594440C34C397FBD7B52C0D8B5B7C0B1594440CFD90A5ECE7B52C0BE8DD86CA45944405C7E229FE07B52C0A904EE5C9C59444017C1F28EF37B52C05E2745E099594440AE8A3873067C52C0FD62540F9D5944402F272292187C52C05502CBCAA5594440C3F17139297C52C0B3FBC4BCB3594440DDAE56C5377C52C00C46175CC6594440E96AB6A6437C52C0355C94F1DC5944402313AE684C7C52C05340159FF6594440B3B90FB5517C52C031F30168125A44407F43B357537C52C0DF95053B2F5A444059C17840517C52C0D9E08EFC4B5A44406580E8834B7C52C046B5B591675A444035736A5A427C52C0AF9A1AEB805A44402E721C1E367C52C0D226550F975A4440506D5C47277C52C0A2968A24A95A4440507C2868167C52C0D51FCE78B65A4440C4438226047C52C02369F888BE5A4440C9F10C36F17B52C027B1B205C15A4440AABE2451DE7B52C0F5E383D6BD5A44402A18B431CC7B52C01785C11AB55A444018320D8ABB7B52C070265B28A75A4440E28A0EFEAC7B52C09E518C88945A44401D08D61CA17B52C09E8195F27D5A4440D7C3405B987B52C0643CB044645A444047B16D0F937B52C04EC9837B485A4440BB366F6D917B52C0E7BB6EA82B5A4440'::geometry, 'Spielman-Singleton Segments: 10 Clusters') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -106,7 +106,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getuscensuscategory(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getuscensuscategory(geometry, unknown) does not exist"])
 
     def test_if_get_population_is_ok(self):
         query = "SELECT OBS_GetPopulation(CDB_LatLng(40.704512, -73.936669)) as population;&api_key={0}".format(self.env_variables['api_key'])
@@ -118,7 +118,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpopulation(geometry) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpopulation(geometry) does not exist"])
 
     def test_if_obs_search_is_ok(self):
         sql = "SELECT id FROM OBS_Search('total_pop') WHERE id LIKE 'es.ine%' LIMIT 1;"
@@ -132,7 +132,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_search(unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_search(unknown) does not exist"])
 
     def test_if_obs_get_available_boundaries_is_ok(self):
         query = "SELECT boundary_id FROM OBS_GetAvailableBoundaries(CDB_LatLng(40.704512, -73.936669)) LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -144,7 +144,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailableboundaries(geometry) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailableboundaries(geometry) does not exist"])
 
     def test_if_obs_get_boundary_is_ok(self):
         query = "SELECT OBS_GetBoundary(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -156,7 +156,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundary(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundary(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundary_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryId(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract', '2015') as boundary_id;&api_key={0}".format(self.env_variables['api_key'])
@@ -168,7 +168,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundaryid(geometry, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundaryid(geometry, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundary_by_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryById('36047', 'us.census.tiger.county', '2014') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -180,7 +180,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundarybyid(unknown, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundarybyid(unknown, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -192,7 +192,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundariesbygeometry(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundariesbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -204,7 +204,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundariesbypointandradius(geometry, integer, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getboundariesbypointandradius(geometry, integer, unknown) does not exist"])
 
     def test_if_obs_get_points_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -216,7 +216,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpointsbygeometry(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpointsbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_points_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract', '2014') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -228,7 +228,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpointsbypointandradius(geometry, integer, unknown, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getpointsbypointandradius(geometry, integer, unknown, unknown) does not exist"])
 
     def test_if_obs_get_legacy_builder_metadata_is_ok(self):
         query = "SELECT name FROM OBS_LegacyBuilderMetadata() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -240,7 +240,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_legacybuildermetadata() does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_legacybuildermetadata() does not exist"])
 
     def test_if_obs_get_available_numerators_is_ok(self):
         query = "SELECT numer_id FROM OBS_GetAvailableNumerators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -252,7 +252,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailablenumerators() does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailablenumerators() does not exist"])
 
     def test_if_obs_get_available_denominators_is_ok(self):
         query = "SELECT denom_id FROM OBS_GetAvailableDenominators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -264,7 +264,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailabledenominators() does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailabledenominators() does not exist"])
 
     def test_if_obs_get_available_geometries_is_ok(self):
         query = "SELECT geom_id FROM OBS_GetAvailableGeometries() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -276,7 +276,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailablegeometries() does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailablegeometries() does not exist"])
 
     def test_if_obs_get_available_timespans_is_ok(self):
         query = "SELECT timespan_id FROM OBS_GetAvailableTimespans() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -288,7 +288,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailabletimespans() does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getavailabletimespans() does not exist"])
 
     def test_if_obs_get_meta_is_ok(self):
         params = '\'[{\"numer_id\": \"us.census.acs.B01003001\"}]\''
@@ -302,7 +302,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
 
     def test_if_obs_get_data_is_ok(self):
         params_1 = '\'[{\"numer_id\": \"us.census.acs.B01003001\", \"geom_id\": \"us.census.tiger.county\"}]\''
@@ -322,8 +322,8 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_1)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_2)
         except Exception as e:
-            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown) does not exist"])
+            assert_in(e.message[0], ["Observatory permission denied", "function obs_getmeta(geometry, unknown) does not exist"])

--- a/test/integration/test_data_observatory_functions.py
+++ b/test/integration/test_data_observatory_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,7 +12,6 @@ class TestDataObservatoryFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_get_demographic_snapshot_is_ok(self):
@@ -25,7 +24,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getdemographicsnapshot(geometry) does not exist"])
 
     def test_if_get_segment_snapshot_is_ok(self):
         query = "SELECT OBS_GetSegmentSnapshot(CDB_LatLng(40.704512, -73.936669)) as snapshot;&api_key={0}".format(self.env_variables['api_key'])
@@ -37,7 +36,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getsegmentsnapshot(geometry) does not exist"])
 
     def test_if_get_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetMeasure(CDB_LatLng(40.704512, -73.936669), 'us.census.acs.B01003001') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -54,7 +53,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_measure_by_id_ok(self):
         query = "SELECT OBS_GetMeasureById('36047048500', 'us.census.acs.B01003001', 'us.census.tiger.census_tract', '2010 - 2014') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -66,7 +65,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeasurebyid(unknown, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_category_is_ok(self):
         query = "SELECT OBS_GetCategory(CDB_LatLng(40.704512, -73.936669), 'us.census.spielman_singleton_segments.X10', 'us.census.tiger.census_tract', '2010 - 2014') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -78,7 +77,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getcategory(geometry, unknown, unknown, unknown) does not exist"])
 
     def test_if_get_us_census_measure_with_point_is_ok(self):
         query = "SELECT OBS_GetUSCensusMeasure(CDB_LatLng(40.704512, -73.936669), 'male population') as measure;&api_key={0}".format(self.env_variables['api_key'])
@@ -95,7 +94,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getuscensusmeasure(geometry, unknown) does not exist"])
 
     def test_if_get_us_census_category_is_ok(self):
         query = "SELECT OBS_GetUSCensusCategory('0103000020E61000000100000021000000BB366F6D917B52C0E7BB6EA82B5A444067224C85937B52C0810205E70E5A4440596D6342997B52C09BED2952F35944400A96386CA27B52C07B6D31F9D95944402B81A0A8AE7B52C0D16B73D5C3594440C34C397FBD7B52C0D8B5B7C0B1594440CFD90A5ECE7B52C0BE8DD86CA45944405C7E229FE07B52C0A904EE5C9C59444017C1F28EF37B52C05E2745E099594440AE8A3873067C52C0FD62540F9D5944402F272292187C52C05502CBCAA5594440C3F17139297C52C0B3FBC4BCB3594440DDAE56C5377C52C00C46175CC6594440E96AB6A6437C52C0355C94F1DC5944402313AE684C7C52C05340159FF6594440B3B90FB5517C52C031F30168125A44407F43B357537C52C0DF95053B2F5A444059C17840517C52C0D9E08EFC4B5A44406580E8834B7C52C046B5B591675A444035736A5A427C52C0AF9A1AEB805A44402E721C1E367C52C0D226550F975A4440506D5C47277C52C0A2968A24A95A4440507C2868167C52C0D51FCE78B65A4440C4438226047C52C02369F888BE5A4440C9F10C36F17B52C027B1B205C15A4440AABE2451DE7B52C0F5E383D6BD5A44402A18B431CC7B52C01785C11AB55A444018320D8ABB7B52C070265B28A75A4440E28A0EFEAC7B52C09E518C88945A44401D08D61CA17B52C09E8195F27D5A4440D7C3405B987B52C0643CB044645A444047B16D0F937B52C04EC9837B485A4440BB366F6D917B52C0E7BB6EA82B5A4440'::geometry, 'Spielman-Singleton Segments: 10 Clusters') as category;&api_key={0}".format(self.env_variables['api_key'])
@@ -107,7 +106,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getuscensuscategory(geometry, unknown) does not exist"])
 
     def test_if_get_population_is_ok(self):
         query = "SELECT OBS_GetPopulation(CDB_LatLng(40.704512, -73.936669)) as population;&api_key={0}".format(self.env_variables['api_key'])
@@ -119,7 +118,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpopulation(geometry) does not exist"])
 
     def test_if_obs_search_is_ok(self):
         sql = "SELECT id FROM OBS_Search('total_pop') WHERE id LIKE 'es.ine%' LIMIT 1;"
@@ -133,7 +132,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_search(unknown) does not exist"])
 
     def test_if_obs_get_available_boundaries_is_ok(self):
         query = "SELECT boundary_id FROM OBS_GetAvailableBoundaries(CDB_LatLng(40.704512, -73.936669)) LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -145,7 +144,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailableboundaries(geometry) does not exist"])
 
     def test_if_obs_get_boundary_is_ok(self):
         query = "SELECT OBS_GetBoundary(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -157,7 +156,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundary(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundary_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryId(CDB_LatLng(40.704512, -73.936669), 'us.census.tiger.census_tract', '2015') as boundary_id;&api_key={0}".format(self.env_variables['api_key'])
@@ -169,7 +168,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundaryid(geometry, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundary_by_id_is_ok(self):
         query = "SELECT OBS_GetBoundaryById('36047', 'us.census.tiger.county', '2014') as boundary;&api_key={0}".format(self.env_variables['api_key'])
@@ -181,7 +180,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundarybyid(unknown, unknown, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -193,7 +192,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundariesbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_boundaries_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetBoundariesByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -205,7 +204,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getboundariesbypointandradius(geometry, integer, unknown) does not exist"])
 
     def test_if_obs_get_points_by_geometry_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByGeometry(ST_MakeEnvelope(-73.9452409744,40.6988851644,-73.9280319214,40.7101254524,4326), 'us.census.tiger.census_tract') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -217,7 +216,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpointsbygeometry(geometry, unknown) does not exist"])
 
     def test_if_obs_get_points_by_point_and_radius_is_ok(self):
         query = "SELECT geom_refs FROM OBS_GetPointsByPointAndRadius(CDB_LatLng(40.704512, -73.936669), 500, 'us.census.tiger.census_tract', '2014') ORDER BY geom_refs ASC LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -229,19 +228,19 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getpointsbypointandradius(geometry, integer, unknown, unknown) does not exist"])
 
     def test_if_obs_get_legacy_builder_metadata_is_ok(self):
         query = "SELECT name FROM OBS_LegacyBuilderMetadata() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
         result = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(result['name'], None)
 
-    def test_if_obs_get_points_by_point_and_radius_without_api_key_raise_error(self):
+    def test_if_legacy_builder_metadata_without_api_key_raise_error(self):
         query = "SELECT name FROM OBS_LegacyBuilderMetadata() LIMIT 1;"
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_legacybuildermetadata() does not exist"])
 
     def test_if_obs_get_available_numerators_is_ok(self):
         query = "SELECT numer_id FROM OBS_GetAvailableNumerators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -253,7 +252,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailablenumerators() does not exist"])
 
     def test_if_obs_get_available_denominators_is_ok(self):
         query = "SELECT denom_id FROM OBS_GetAvailableDenominators() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -265,7 +264,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailabledenominators() does not exist"])
 
     def test_if_obs_get_available_geometries_is_ok(self):
         query = "SELECT geom_id FROM OBS_GetAvailableGeometries() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -277,7 +276,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailablegeometries() does not exist"])
 
     def test_if_obs_get_available_timespans_is_ok(self):
         query = "SELECT timespan_id FROM OBS_GetAvailableTimespans() LIMIT 1;&api_key={0}".format(self.env_variables['api_key'])
@@ -289,7 +288,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getavailabletimespans() does not exist"])
 
     def test_if_obs_get_meta_is_ok(self):
         params = '\'[{\"numer_id\": \"us.census.acs.B01003001\"}]\''
@@ -303,7 +302,7 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
 
     def test_if_obs_get_data_is_ok(self):
         params_1 = '\'[{\"numer_id\": \"us.census.acs.B01003001\", \"geom_id\": \"us.census.tiger.county\"}]\''
@@ -323,8 +322,8 @@ class TestDataObservatoryFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_1)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown, integer, integer, integer) does not exist"])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query_2)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Observatory permission denied", "function obs_getmeta(geometry, unknown) does not exist"])

--- a/test/integration/test_ipaddress_functions.py
+++ b/test/integration/test_ipaddress_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,22 +12,21 @@ class TestPostalcodeFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_ipaddress_point_is_ok(self):
         query = "SELECT cdb_geocode_ipaddress_point(ip) " \
             "as geometry FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_ipaddress_without_api_key_raise_error(self):
         query = "SELECT cdb_geocode_ipaddress_point(ip) " \
             "as geometry FROM {0} LIMIT 1".format(
-            self.env_variables['table_name'])
+                self.env_variables['table_name'])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_ipaddress_point(text) does not exist"])

--- a/test/integration/test_ipaddress_functions.py
+++ b/test/integration/test_ipaddress_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -29,4 +29,4 @@ class TestPostalcodeFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_ipaddress_point(text) does not exist"])
+            assert_in(e.message[0], ["Geocoding permission denied", "function cdb_geocode_ipaddress_point(text) does not exist"])

--- a/test/integration/test_isolines_functions.py
+++ b/test/integration/test_isolines_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -27,7 +27,7 @@ class TestIsolinesFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Isolines permission denied", "function cdb_isochrone(geometry, unknown, integer[]) does not exist"])
+            assert_in(e.message[0], ["Isolines permission denied", "function cdb_isochrone(geometry, unknown, integer[]) does not exist"])
 
     def test_if_select_with_isodistance_is_ok(self):
         query = "SELECT * FROM cdb_isodistance('POINT(-3.70568 40.42028)'::geometry, " \
@@ -42,4 +42,4 @@ class TestIsolinesFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Isolines permission denied", "function cdb_isodistance(geometry, unknown, integer[]) does not exist"])
+            assert_in(e.message[0], ["Isolines permission denied", "function cdb_isodistance(geometry, unknown, integer[]) does not exist"])

--- a/test/integration/test_isolines_functions.py
+++ b/test/integration/test_isolines_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,7 +12,6 @@ class TestIsolinesFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_isochrones_is_ok(self):
@@ -28,7 +27,7 @@ class TestIsolinesFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Isolines permission denied", "function cdb_isochrone(geometry, unknown, integer[]) does not exist"])
 
     def test_if_select_with_isodistance_is_ok(self):
         query = "SELECT * FROM cdb_isodistance('POINT(-3.70568 40.42028)'::geometry, " \
@@ -43,4 +42,4 @@ class TestIsolinesFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Isolines permission denied", "function cdb_isodistance(geometry, unknown, integer[]) does not exist"])

--- a/test/integration/test_namedplace_functions.py
+++ b/test/integration/test_namedplace_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,38 +12,37 @@ class TestNameplaceFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_namedplace_city_is_ok(self):
         query = "SELECT cdb_geocode_namedplace_point(city) as geometry " \
             "FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_namedplace_city_country_is_ok(self):
         query = "SELECT cdb_geocode_namedplace_point(city,country) " \
             "as geometry FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_namedplace_city_province_country_is_ok(self):
         query = "SELECT cdb_geocode_namedplace_point(city,province,country) " \
             "as geometry FROM {0} LIMIT 1&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_namedplace_without_api_key_raise_error(self):
         query = "SELECT cdb_geocode_namedplace_point(city) as geometry " \
             "FROM {0} LIMIT 1".format(
-            self.env_variables['table_name'])
+               self.env_variables['table_name'])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_namedplace_point(text) does not exist"])

--- a/test/integration/test_namedplace_functions.py
+++ b/test/integration/test_namedplace_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -45,4 +45,4 @@ class TestNameplaceFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_namedplace_point(text) does not exist"])
+            assert_in(e.message[0], ["Geocoding permission denied", "function cdb_geocode_namedplace_point(text) does not exist"])

--- a/test/integration/test_postalcode_functions.py
+++ b/test/integration/test_postalcode_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,30 +12,29 @@ class TestPostalcodeFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_postalcode_polygon_is_ok(self):
         query = "SELECT cdb_geocode_postalcode_polygon(postalcode, country) " \
             "as geometry FROM {0} WHERE country='USA'&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_postalcode_point_is_ok(self):
         query = "SELECT cdb_geocode_postalcode_point(postalcode, country) " \
             "as geometry FROM {0} WHERE country='Spain'&api_key={1}".format(
-            self.env_variables['table_name'],
-            self.env_variables['api_key'])
+                self.env_variables['table_name'],
+                self.env_variables['api_key'])
         geometry = IntegrationTestHelper.execute_query(self.sql_api_url, query)
         assert_not_equal(geometry['geometry'], None)
 
     def test_if_select_with_postalcode_without_api_key_raise_error(self):
         query = "SELECT cdb_geocode_postalcode_polygon(postalcode, country) " \
             "as geometry FROM {0} WHERE country = 'USA'".format(
-            self.env_variables['table_name'])
+                self.env_variables['table_name'])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_postalcode_polygon(text, text) does not exist"])

--- a/test/integration/test_postalcode_functions.py
+++ b/test/integration/test_postalcode_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -37,4 +37,4 @@ class TestPostalcodeFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Geocoding permission denied", "function cdb_geocode_postalcode_polygon(text, text) does not exist"])
+            assert_in(e.message[0], ["Geocoding permission denied", "function cdb_geocode_postalcode_polygon(text, text) does not exist"])

--- a/test/integration/test_routing_functions.py
+++ b/test/integration/test_routing_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_equal
+from nose.tools import assert_not_equal, assert_true
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -12,7 +12,6 @@ class TestRoutingFunctions(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
     def test_if_select_with_routing_point_to_point_is_ok(self):
@@ -32,7 +31,7 @@ class TestRoutingFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Routing permission denied", "function cdb_route_point_to_point(geometry, geometry, unknown, text[]) does not exist"])
 
     def test_if_select_with_routing_with_waypoints_is_ok(self):
         query = "SELECT duration, length, shape as the_geom " \
@@ -46,11 +45,12 @@ class TestRoutingFunctions(TestCase):
 
     def test_if_select_with_routing_with_waypoints_without_api_key_raise_error(self):
         query = "SELECT duration, length, shape as the_geom " \
-                "FROM cdb_route_with_waypoints(Array['POINT(-3.7109 40.4234)'::GEOMETRY, "\
+                "FROM cdb_route_with_waypoints(Array['POINT(-3.7109 40.4234)'::geometry, "\
                 "'POINT(-3.7059 40.4203)'::geometry, 'POINT(-3.7046 40.4180)'::geometry]" \
                 "::geometry[], 'car', " \
-                "ARRAY['mode_type=shortest']::text[])&api_key={0}"
+                "ARRAY['mode_type=shortest']::text[])&api_key={0}".format(
+                    self.env_variables['api_key'])
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_equal(e.message[0], "The api_key must be provided")
+            assert_true(e.message[0] in ["Routing permission denied", "function cdb_route_with_waypoints(geometry, geometry, text, text[]) does not exist"])

--- a/test/integration/test_routing_functions.py
+++ b/test/integration/test_routing_functions.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from nose.tools import assert_raises
-from nose.tools import assert_not_equal, assert_true
+from nose.tools import assert_not_equal, assert_in
 from ..helpers.integration_test_helper import IntegrationTestHelper
 
 
@@ -31,7 +31,7 @@ class TestRoutingFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Routing permission denied", "function cdb_route_point_to_point(geometry, geometry, unknown, text[]) does not exist"])
+            assert_in(e.message[0], ["Routing permission denied", "function cdb_route_point_to_point(geometry, geometry, unknown, text[]) does not exist"])
 
     def test_if_select_with_routing_with_waypoints_is_ok(self):
         query = "SELECT duration, length, shape as the_geom " \
@@ -53,4 +53,4 @@ class TestRoutingFunctions(TestCase):
         try:
             IntegrationTestHelper.execute_query(self.sql_api_url, query)
         except Exception as e:
-            assert_true(e.message[0] in ["Routing permission denied", "function cdb_route_with_waypoints(geometry, geometry, text, text[]) does not exist"])
+            assert_in(e.message[0], ["Routing permission denied", "function cdb_route_with_waypoints(geometry, geometry, text, text[]) does not exist"])

--- a/test/integration/test_street_functions.py
+++ b/test/integration/test_street_functions.py
@@ -110,7 +110,6 @@ class TestStreetFunctionsSetUp(TestCase):
             self.env_variables['schema'],
             self.env_variables['username'],
             self.env_variables['host'],
-            self.env_variables['api_key']
         )
 
         if not self.fixture_points:
@@ -122,7 +121,6 @@ class TestStreetFunctionsSetUp(TestCase):
             self.fixture_points = self.FIXTURE_POINTS[provider]
 
             self.metadata = self.METADATAS[provider]
-
 
     def _run_authenticated(self, query):
         authenticated_query = "{}&api_key={}".format(query,
@@ -136,6 +134,7 @@ class TestStreetFunctionsSetUp(TestCase):
                 "from cdb_dataservices_client.cdb_service_quota_info() " \
                 "where service = 'hires_geocoder'"
         return self._run_authenticated(query)['rows'][0]['used_quota']
+
 
 class TestStreetFunctions(TestStreetFunctionsSetUp):
 


### PR DESCRIPTION
Fixed integration tests.
Related to https://github.com/CartoDB/cartodb/issues/14283

Tests must handle two error messages, since for public api keys in non-org roles (which use postgres built-in `public` role) the DS client schema is not in the search path. See https://github.com/CartoDB/cartodb/issues/14283