### PR TITLE
Fix altered public method of TomTomGeocoder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+Mar 13rd, 2019
+==============
+* Version `0.21.4` of the python library
+    * Fix TomTom bulk geocoder bug (#551)
+
 Mar 5th, 2019
 ==============
 * Version `0.21.3` of the python library

--- a/server/lib/python/cartodb_services/cartodb_services/tomtom/geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/tomtom/geocoder.py
@@ -73,15 +73,19 @@ class TomTomGeocoder(Traceable):
     @qps_retry(qps=5, provider='tomtom')
     def geocode(self, searchtext, city=None, state_province=None,
                 country=None):
-        geocoder_response, http_response = self.geocode_meta(searchtext, city, state_province, country)
+        geocoder_response, http_response = self._geocode_meta(searchtext, city, state_province, country)
         error_message = geocoder_response[1].get('error', None)
         if error_message:
             raise ServiceException(error_message, http_response)
         else:
             return geocoder_response[0]
 
-    @qps_retry(qps=5, provider='tomtom')
     def geocode_meta(self, searchtext, city=None, state_province=None,
+                country=None):
+        return self._geocode_meta(searchtext, city, state_province, country)[0]
+
+    @qps_retry(qps=5, provider='tomtom')
+    def _geocode_meta(self, searchtext, city=None, state_province=None,
                 country=None):
         if searchtext:
             searchtext = searchtext.decode('utf-8')

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.21.3',
+    version='0.21.4',
 
     description='CartoDB Services API Python Library',
 


### PR DESCRIPTION
In #456 the public method geocode_meta return value was changed (to a tuple). The intention was to be consumed only from the same class.