### PR TITLE
Show the differences that caused some tests to fail in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,14 @@ jobs:
         run: docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "cd /dataservices-api/server/extension/ && sudo make clean all install installcheck"
         timeout-minutes: 5
 
+      - name: Show failing server tests
+        if: failure()
+        run: docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "cat /dataservices-api/server/extension/test/regression.diffs"
+
       - name: Run client tests
         run: docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "sudo createuser publicuser --no-createrole --no-createdb --no-superuser -U postgres && cd /dataservices-api/client/ && sudo make clean all install installcheck"
         timeout-minutes: 5
+
+      - name: Show failing client tests
+        if: failure()
+        run: docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "cat /dataservices-api/client/test/regression.diffs"


### PR DESCRIPTION
Now we can have a clue about what failed in CI:

```diff
Run docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "cat /dataservices-api/server/extension/test/regression.diffs"
  docker-compose -f docker-compose.yaml exec -T postgres-server bash -c "cat /dataservices-api/server/extension/test/regression.diffs"
  shell: /bin/bash -e {0}
  env:
    PG_VERSION: 12
    CLOUDSDK_METRICS_ENVIRONMENT: github-actions-setup-gcloud
diff -U3 /dataservices-api/server/extension/test/expected/00_install_test.out /dataservices-api/server/extension/test/results/00_install_test.out
--- /dataservices-api/server/extension/test/expected/00_install_test.out	2020-03-04 18:18:34.538370583 +0000
+++ /dataservices-api/server/extension/test/results/00_install_test.out	2020-03-04 18:20:43.964373771 +0000
@@ -3,66 +3,55 @@
 -- Install dependencies
 CREATE EXTENSION postgis;
 CREATE EXTENSION plpythonu;
+ERROR:  could not open extension control file "/usr/share/postgresql/12/extension/plpythonu.control": No such file or directory
 CREATE EXTENSION plproxy;
 CREATE EXTENSION cartodb;
+ERROR:  required extension "plpython3u" is not installed
+HINT:  Use CREATE EXTENSION ... CASCADE to install required extensions too.
 CREATE EXTENSION cdb_geocoder;
+ERROR:  required extension "cartodb" is not installed
[....]
```