### PR TITLE
Fixing is_destination for HERE isolines

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/here/routing.py
+++ b/server/lib/python/cartodb_services/cartodb_services/here/routing.py
@@ -115,7 +115,7 @@ class HereMapsRoutingIsoline(Traceable):
 
     def __parse_source_param(self, source, options):
         key = 'start'
-        if 'is_destination' in options and options['is_destination']:
+        if 'is_destination' in options and options['is_destination'].lower() == 'true':
             key = 'destination'
 
         return {key: source}

--- a/server/lib/python/cartodb_services/setup.py
+++ b/server/lib/python/cartodb_services/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name='cartodb_services',
 
-    version='0.23.1',
+    version='0.23.2',
 
     description='CartoDB Services API Python Library',
 

--- a/server/lib/python/cartodb_services/test/test_heremapsrouting.py
+++ b/server/lib/python/cartodb_services/test/test_heremapsrouting.py
@@ -133,6 +133,7 @@ class HereMapsRoutingIsolineTestCase(unittest.TestCase):
         self.isoline_url = "{0}{1}".format(HereMapsRoutingIsoline.PRODUCTION_ROUTING_BASE_URL,
                                      HereMapsRoutingIsoline.ISOLINE_PATH)
 
+
     def test_calculate_isodistance_with_valid_params(self, req_mock):
         url = "{0}?start=geo%2133.0%2C1.0&mode=shortest%3Bcar".format(self.isoline_url)
         req_mock.register_uri('GET', url, text=self.GOOD_RESPONSE)
@@ -208,9 +209,21 @@ class HereMapsRoutingIsolineTestCase(unittest.TestCase):
                               text=self.GOOD_RESPONSE)
         response = self.routing.calculate_isochrone('geo!33.0,1.0', 'car',
                                                     ['1000', '2000'],
+                                                    ['is_destination=false'])
+        parsed_url = urlparse(req_mock.request_history[0].url)
+        url_params = parse_qs(parsed_url.query)
+
+        self.assertEqual(url_params['start'][0], 'geo!33.0,1.0')
+
+    def test_destination_parameters_works_properly(self, req_mock):
+        req_mock.register_uri('GET', requests_mock.ANY,
+                              text=self.GOOD_RESPONSE)
+        response = self.routing.calculate_isochrone('geo!33.0,1.0', 'car',
+                                                    ['1000', '2000'],
                                                     ['is_destination=true'])
         parsed_url = urlparse(req_mock.request_history[0].url)
         url_params = parse_qs(parsed_url.query)
+
         self.assertEqual(url_params['destination'][0], 'geo!33.0,1.0')
 
     def test_isodistance_with_nonstandard_url(self, req_mock):

--- a/server/lib/python/cartodb_services/test/test_heremapsrouting.py
+++ b/server/lib/python/cartodb_services/test/test_heremapsrouting.py
@@ -133,7 +133,6 @@ class HereMapsRoutingIsolineTestCase(unittest.TestCase):
         self.isoline_url = "{0}{1}".format(HereMapsRoutingIsoline.PRODUCTION_ROUTING_BASE_URL,
                                      HereMapsRoutingIsoline.ISOLINE_PATH)
 
-
     def test_calculate_isodistance_with_valid_params(self, req_mock):
         url = "{0}?start=geo%2133.0%2C1.0&mode=shortest%3Bcar".format(self.isoline_url)
         req_mock.register_uri('GET', url, text=self.GOOD_RESPONSE)
@@ -212,7 +211,6 @@ class HereMapsRoutingIsolineTestCase(unittest.TestCase):
                                                     ['is_destination=false'])
         parsed_url = urlparse(req_mock.request_history[0].url)
         url_params = parse_qs(parsed_url.query)
-
         self.assertEqual(url_params['start'][0], 'geo!33.0,1.0')
 
     def test_destination_parameters_works_properly(self, req_mock):
@@ -223,7 +221,6 @@ class HereMapsRoutingIsolineTestCase(unittest.TestCase):
                                                     ['is_destination=true'])
         parsed_url = urlparse(req_mock.request_history[0].url)
         url_params = parse_qs(parsed_url.query)
-
         self.assertEqual(url_params['destination'][0], 'geo!33.0,1.0')
 
     def test_isodistance_with_nonstandard_url(self, req_mock):


### PR DESCRIPTION
Fixing `is_destination` parameter for HERE isolines

Related to https://github.com/CartoDB/support/issues/2449