### PR TITLE
HERE Bulk geocoder: Read all responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-Nov 11th, 2020
+Nov 18th, 2020
 ==============
 * Version `0.39.2` of the server extension
 * Version `0.23.4` of the Python library
     * Better messages on remote errors.
     * Fix error on unknown status codes.
+    * Here bulk geocoder: Return also errors and no-matches.
 
 Sep 23th, 2020
 ==============

--- a/server/lib/python/cartodb_services/cartodb_services/here/bulk_geocoder.py
+++ b/server/lib/python/cartodb_services/cartodb_services/here/bulk_geocoder.py
@@ -126,7 +126,7 @@ class HereMapsBulkGeocoder(HereMapsGeocoder, StreetPointBulkGeocoder):
             status=polling_root.find('./Response/Status').text)
 
     def _download_results(self, job_id):
-        result_r = self.session.get("{}/{}/result".format(self.BATCH_URL, job_id),
+        result_r = self.session.get("{}/{}/all".format(self.BATCH_URL, job_id),
                                     params=self.credentials_params,
                                     timeout=(self.connect_timeout, self.read_timeout))
         root_zip = zipfile.ZipFile(io.BytesIO(result_r.content))
@@ -147,6 +147,9 @@ class HereMapsBulkGeocoder(HereMapsGeocoder, StreetPointBulkGeocoder):
                                             precision,
                                             [match_type] if match_type else []
                                         )))
-
+                    elif row['matchLevel'] == 'NOMATCH':
+                        results.append((row['recId'], [], {}))
+                    elif row['matchLevel'] == 'FAILED':
+                        results.append((row['recId'], [], {'error': 'Bulk geocoder failed'}))
         return results
 


### PR DESCRIPTION
Modify the HERE bulk geocoder to not only read the positive results but also the ids that weren't matched and the input errors.

Example forcing the bulk geocoder to trigger below the limit (100):

```sql
SELECT * FROM cdb_dataservices_server._cdb_bulk_geocode_street_point ('rmrodriguez'::text, NULL::text,
'[{"id": 722, "city": "Gloucester", "state": "ON", "address": "2599 Innes chemin", "country": "Canada"}, 
  {"id": 723, "city": "Marionville", "state": "ON", "address": "9575 Marionville chemin", "country": "Canada"},
  {"id": 735, "city": "Subdury",  "state": "ON", "address": "504 St-Raphael rue", "country": "Canada"},
  {"id": 100, "city": null, "state": null, "address": null, "country": null}]'::jsonb);
```

In this case HERE returns the address for 722, doesn't match 723 and 735 and returns an error for 100.

The old result:
```
 cartodb_id |                      the_geom                      |                                   metadata                                   
------------+----------------------------------------------------+------------------------------------------------------------------------------
        722 | 0101000020E61000004339D1AE42E452C0CF49EF1B5FB74640 | {"precision": "precise", "relevance": 1.0, "match_types": ["street_number"]}
(1 row)
```

The new result:
```
cartodb_id |                      the_geom                      |                                   metadata                                   
------------+----------------------------------------------------+------------------------------------------------------------------------------
        100 |                                                    | {"error": "Bulk geocoder failed"}
        722 | 0101000020E61000004339D1AE42E452C0CF49EF1B5FB74640 | {"precision": "precise", "relevance": 1.0, "match_types": ["street_number"]}
        723 |                                                    | {}
        735 |                                                    | {}
(4 rows)
```

References ch102254