### PR TITLE
[ch135234] Remove 'public_transport' mode from routing documentation

### DIFF
--- a/docs/developer-center/reference/08-routing-functions.md
+++ b/docs/developer-center/reference/08-routing-functions.md
@@ -12,7 +12,7 @@ Name | Type | Description | Accepted values
 --- | --- | --- | ---
 `origin` | `geometry(Point)` | Origin point, in 4326 projection, which defines the start location. |
 `destination` | `geometry(Point)` | Destination point, in 4326 projection, which defines the end location. |
-`mode` | `text` | Type of transport used to calculate the routes. | `car`, `walk`, `bicycle` or `public_transport`
+`mode` | `text` | Type of transport used to calculate the routes. | `car`, `walk` or `bicycle`
 `options` | `text[]` | (Optional) Multiple options to add more capabilities to the analysis. See [Optional routing parameters](#optional-routing-parameters) for details.
 `units` | `text` | (Optional) Unit used to represent the length of the route. | `kilometers`, `miles`. By default is `kilometers`. This option is not supported by Mapbox provider
 
@@ -47,7 +47,7 @@ Returns a route that goes from origin to destination and whose path travels thro
 Name | Type | Description | Accepted values
 --- | --- | --- | ---
 `waypoints` | `geometry(Point)[]` | Array of ordered points, in 4326 projection, which defines the origin point, one or more locations for the route path to travel through, and the destination. The first element of the array defines the origin and the last element the destination of the route. |
-`mode` | `text` | Type of transport used to calculate the routes. | `car`, `walk`, `bicycle` or `public_transport`
+`mode` | `text` | Type of transport used to calculate the routes. | `car`, `walk` or `bicycle`
 `options` | `text[]` | (Optional) Multiple options to add more capabilities to the analysis. See [Optional routing parameters](#optional-routing-parameters) for details.
 `units` | `text` | (Optional) Unit used to represent the length of the route. | `kilometers`, `miles`. By default is `kilometers`. This option is not supported by Mapbox provider
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/135234/bain-routing-public-transport-parameter)

### Context

- The valid `mode` options for routing are outdated. The current list refers to [Mapzen provider](https://github.com/CartoDB/dataservices-api/blob/ce27c2da0a476ebd999bc908733c0978079af0a4/server/lib/python/cartodb_services/cartodb_services/mapzen/routing.py#L22-L27), and it is using `public_transport` as alias for `bus` mode.
-  Right now, we are not supporting that type through [TomTom provider](https://github.com/CartoDB/dataservices-api/blob/ce27c2da0a476ebd999bc908733c0978079af0a4/server/lib/python/cartodb_services/cartodb_services/tomtom/types.py#L26), and the [`bus` mode from TomTom is still in BETA](https://developer.tomtom.com/routing-api/routing-api-documentation-routing/common-routing-parameters): `Note that travel modes bus, motorcycle, taxi, and van are in BETA functionality. Full restriction data is not available in all areas.`. So, [it was decided](https://app.clubhouse.io/cartoteam/story/135234/bain-routing-public-transport-parameter#activity-137144) to update the documentation in order to remove the invalid `public_transport` mode until the TomTom `bus` option is not in beta.


### Changes

- Remove `public_transport` from the list of valid modes for routing methods.