### PR TITLE
Update news for support new here api keys feature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+May 26th, 2021
+==============
+* Version `0.40.1` of the server extension
+* Version `0.24.1` of the Python library
+    * Support new HERE API keys
+
 Mar 4th, 2021
 =============
 * Version `0.31.0` of the client extension


### PR DESCRIPTION
Updating NEWS.md as part of https://github.com/CartoDB/dataservices-api/pull/622 