### PR TITLE
Add mode_feature parameter to HERE V8 isolines

### DIFF
--- a/server/lib/python/cartodb_services/cartodb_services/here/routing.py
+++ b/server/lib/python/cartodb_services/cartodb_services/here/routing.py
@@ -180,7 +180,8 @@ class HereMapsRoutingIsolineV8(Traceable):
         'departure',
         'arrival',
         'maxpoints',
-        'quality'
+        'quality',
+        'mode_feature'
     ]
 
     def __init__(self, apikey, logger, service_params=None):
@@ -257,7 +258,8 @@ class HereMapsRoutingIsolineV8(Traceable):
             'start': 'origin',
             'destination': 'destination',
             'departure': 'departuretime',
-            'arrival': 'arrivaltime'
+            'arrival': 'arrivaltime',
+            'mode_feature': 'avoid[features]'
         }
 
         if reverse is True:


### PR DESCRIPTION
Add parameter `mode_feature` that was lost due to the migration from HERE API v7 to v8 a few months ago.

```
dataservices_1                | DEBUG:urllib3.connectionpool:https://isoline.router.hereapi.com:443 "GET /v8/isolines?origin=40.420280%2C-3.705680&range%5Bvalues%5D=1800&apikey=xxxx&routingmode=short&optimizefor=quality&avoid%5Bfeatures%5D=tollroad&transportmode=car&range%5Btype%5D=time HTTP/1.1" 200 None
```